### PR TITLE
Добавлен тест границы для goToPreviousPage

### DIFF
--- a/feature-reader/src/test/java/com/example/feature/reader/ui/ReaderViewModelTest.kt
+++ b/feature-reader/src/test/java/com/example/feature/reader/ui/ReaderViewModelTest.kt
@@ -144,6 +144,26 @@ class ReaderViewModelTest {
     }
 
     @Test
+    fun `goToPreviousPage - does nothing when on first page`() = runTest {
+        // Arrange
+        val mockBitmap: Bitmap = mock()
+        whenever(bookReader.open(testFile)).doReturn(2) // 2 pages (0, 1)
+        whenever(bookReader.renderPage(any())).doReturn(mockBitmap)
+        viewModel.openBook(testFile) // initial state: page 0
+
+        val stateBefore = viewModel.uiState.value
+        clearInvocations(bookReader) // reset invocation history
+
+        // Act
+        viewModel.goToPreviousPage() // try to go before page 0
+
+        // Assert
+        verify(bookReader, never()).renderPage(any())
+        val state = viewModel.uiState.value
+        assertThat(state).isSameInstanceAs(stateBefore)
+    }
+
+    @Test
     fun `loadPage failure - renderPage returns null updates state with error`() = runTest {
         // Arrange
         whenever(bookReader.open(testFile)).doReturn(10)


### PR DESCRIPTION
## Summary
- доработан тест `goToPreviousPage` для проверки отсутствия лишнего рендеринга и сохранения состояния

## Testing
- `./gradlew :feature-reader:test --no-daemon` *(падает: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b2a921000832eb996e8d86fed9f28