### PR TITLE
Fix BookReaderFactory KDoc param

### DIFF
--- a/feature-reader/src/main/java/com/example/feature/reader/domain/BookReaderFactory.kt
+++ b/feature-reader/src/main/java/com/example/feature/reader/domain/BookReaderFactory.kt
@@ -21,9 +21,9 @@ class BookReaderFactory @Inject constructor(
     private val bitmapCache: BitmapCache
 ) {
     /**
-     * Creates a [BookReader] for the given file.
+     * Creates a [BookReader] for the given URI.
      *
-     * @param file The file to create a reader for.
+     * @param uri The URI of the file to create a reader for.
      * @return A [BookReader] instance suitable for the file type.
      * @throws UnsupportedFormatException if the file format is not supported.
      */


### PR DESCRIPTION
## Summary
- fix mismatched parameter name in BookReaderFactory

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b2a901acc832e876d882f4f1c2100