### PR TITLE
Fix LoadComicUseCase reader factory call

### DIFF
--- a/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
@@ -8,7 +8,7 @@ class LoadComicUseCase @Inject constructor(
     private val bookReaderFactory: BookReaderFactory
 ) {
     suspend operator fun invoke(uri: Uri) {
-        bookReaderFactory.createReader(uri)
+        bookReaderFactory.create(uri)
     }
 
     fun releaseResources() {


### PR DESCRIPTION
## Summary
- use `BookReaderFactory.create()` instead of deprecated `createReader`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b2a8da7b8832ea21cc309059fdab6