### PR TITLE
Update DeveloperHandoff with Android SDK setup

### DIFF
--- a/docs/DeveloperHandoff.md
+++ b/docs/DeveloperHandoff.md
@@ -31,6 +31,23 @@
 *   **Retrofit/OkHttp:** Для сетевых запросов (если применимо).
 *   **FolioReader:** Для поддержки EPUB.
 
+## Установка Android SDK
+
+Для сборки и тестирования Android-проектов требуется установленный Android SDK. Скачайте пакет `commandlinetools` с [официального сайта Android](https://developer.android.com/studio) и распакуйте его в удобную директорию, например `/opt/android-sdk`.
+
+1.  Создайте переменную окружения `ANDROID_SDK_ROOT` и добавьте инструменты SDK в `PATH`:
+    ```bash
+    export ANDROID_SDK_ROOT=/opt/android-sdk
+    export PATH="$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools"
+    ```
+    Эти строки можно добавить в `~/.bashrc` или `~/.zshrc` для автоматической настройки при запуске терминала.
+
+2.  Установите необходимые компоненты SDK:
+    ```bash
+    sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0" "cmdline-tools;latest"
+    ```
+    При необходимости укажите актуальные версии Android API и build-tools.
+
 ## Процесс сборки
 
 Проект собирается с использованием Gradle. Для сборки отладочной версии выполните:


### PR DESCRIPTION
## Summary
- add section detailing how to install and configure the Android SDK

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bb6d03d30832eb6ed7ca37223f29b