### PR TITLE
Implement Result-based error handling

### DIFF
--- a/core-domain/src/main/java/com/example/core/domain/usecase/AddComicUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/AddComicUseCase.kt
@@ -7,8 +7,13 @@ import javax.inject.Inject
 class AddComicUseCase @Inject constructor(
     private val repository: LibraryRepository
 ) {
-    suspend operator fun invoke(comic: Comic) {
-        repository.addComic(comic)
+    suspend operator fun invoke(comic: Comic): Result<Unit> {
+        return try {
+            repository.addComic(comic)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 }
 

--- a/core-domain/src/main/java/com/example/core/domain/usecase/DeleteComicUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/DeleteComicUseCase.kt
@@ -6,8 +6,13 @@ import javax.inject.Inject
 class DeleteComicUseCase @Inject constructor(
     private val repository: LibraryRepository
 ) {
-    suspend operator fun invoke(comicId: String) {
-        repository.deleteComic(comicId)
+    suspend operator fun invoke(comicIds: Set<String>): Result<Unit> {
+        return try {
+            comicIds.forEach { repository.deleteComic(it) }
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 }
 

--- a/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
@@ -7,14 +7,23 @@ import javax.inject.Inject
 class GetComicPagesUseCase @Inject constructor(
     private val bookReaderFactory: BookReaderFactory
 ) {
-    fun getTotalPages(): Int {
-        return bookReaderFactory.getCurrentReader()?.let { reader ->
-            reader.open(bookReaderFactory.getCurrentUri()!!)
-        } ?: 0
+    fun getTotalPages(): Result<Int> {
+        return try {
+            val pages = bookReaderFactory.getCurrentReader()?.let { reader ->
+                reader.open(bookReaderFactory.getCurrentUri()!!)
+            } ?: 0
+            Result.Success(pages)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 
-    fun getPage(pageIndex: Int): Bitmap? {
-        return bookReaderFactory.getCurrentReader()?.renderPage(pageIndex)
+    fun getPage(pageIndex: Int): Result<Bitmap?> {
+        return try {
+            Result.Success(bookReaderFactory.getCurrentReader()?.renderPage(pageIndex))
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 }
 

--- a/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
@@ -6,8 +6,12 @@ import javax.inject.Inject
 class GetReadingProgressUseCase @Inject constructor(
     private val repository: ComicRepository
 ) {
-    suspend operator fun invoke(comicId: String): Int {
-        return repository.getReadingProgress(comicId)
+    suspend operator fun invoke(comicId: String): Result<Int> {
+        return try {
+            Result.Success(repository.getReadingProgress(comicId))
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 }
 

--- a/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
@@ -7,8 +7,13 @@ import javax.inject.Inject
 class LoadComicUseCase @Inject constructor(
     private val bookReaderFactory: BookReaderFactory
 ) {
-    suspend operator fun invoke(uri: Uri) {
-        bookReaderFactory.create(uri)
+    suspend operator fun invoke(uri: Uri): Result<Unit> {
+        return try {
+            bookReaderFactory.create(uri)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 
     fun releaseResources() {

--- a/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
+++ b/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
@@ -6,8 +6,13 @@ import javax.inject.Inject
 class SaveReadingProgressUseCase @Inject constructor(
     private val repository: ComicRepository
 ) {
-    suspend operator fun invoke(comicId: String, currentPage: Int) {
-        repository.updateProgress(comicId, currentPage)
+    suspend operator fun invoke(comicId: String, currentPage: Int): Result<Unit> {
+        return try {
+            repository.updateProgress(comicId, currentPage)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- use `Result` wrapper in key domain usecases
- surface errors through `LibraryViewModel` and `ReaderViewModel`

## Testing
- `./gradlew spotlessCheck` *(fails: task not found)*
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687cb8882808832e8fbc3bd85a0b1f9a