### PR TITLE
Implement comic count on LibraryScreen

### DIFF
--- a/feature-library/src/main/java/com/example/feature/library/ui/LibraryScreen.kt
+++ b/feature-library/src/main/java/com/example/feature/library/ui/LibraryScreen.kt
@@ -152,6 +152,8 @@ private fun LibraryScreenContent(
         }
     }
 
+    val visibleComics = uiState.comics.filter { it.filePath !in uiState.pendingDeletionIds }
+
     Scaffold(
         topBar = {
             if (uiState.inSelectionMode) {
@@ -168,7 +170,7 @@ private fun LibraryScreenContent(
                 )
             } else {
                 MrComicTopAppBar(
-                    title = "Library",
+                    title = "Library (${visibleComics.size})",
                     actions = {
                         IconButton(onClick = onToggleSearch) {
                             Icon(Icons.Default.Search, contentDescription = "Search")
@@ -213,7 +215,6 @@ private fun LibraryScreenContent(
                 } else if (uiState.error != null) {
                     Text(text = uiState.error)
                 } else {
-                    val visibleComics = uiState.comics.filter { it.filePath !in uiState.pendingDeletionIds }
                     if (visibleComics.isEmpty()) {
                         Text("No comics found.")
                     }


### PR DESCRIPTION
## Summary
- filter out pending deletions once and reuse the list
- show number of comics in LibraryScreen title

## Testing
- `./gradlew :feature-library:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68802a716764832ebc68d804fc39e61e