### PR TITLE
fix: decouple translation package

### DIFF
--- a/backend/mrcomic-ocr-translation/src/translation/__init__.py
+++ b/backend/mrcomic-ocr-translation/src/translation/__init__.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-Инициализация пакета translation
+"""Инициализация пакета ``translation``.
+
+Модуль предоставляет только базовые интерфейсы перевода. Конкретные
+реализации переводчиков импортируются фабрикой по требованию, что
+позволяет использовать отдельные подсистемы (например, кэш переводов)
+без установки дополнительных зависимостей.
 """
 
-# Импортируем основные классы для удобства использования
 from .translator_interface import TranslatorInterface, TranslatorFactory
-from .google_translator import GoogleTranslator
-from .libre_translator import LibreTranslator
-from .fallback_translator import FallbackTranslator
 
-# Обновляем фабрику для поддержки fallback-переводчика
-TranslatorFactory._create_fallback = lambda config: FallbackTranslator(config)
+__all__ = ["TranslatorInterface", "TranslatorFactory"]


### PR DESCRIPTION
## Summary
- avoid importing heavy translator implementations when loading translation package
- keep translation cache usable without optional dependencies

## Testing
- `python backend/mrcomic-ocr-translation/test_cache.py`
- `python backend/mrcomic-ocr-translation/test_translator.py fallback`


------
https://chatgpt.com/codex/tasks/task_b_688e3768fb10832ca4192b91dc0af691