### PR TITLE
Remove outdated legacy comic reader code and commit previous fixes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,6 +30,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Install the Android SDK and required build components
+      - name: 📱 Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          components: platform-tools, platforms;android-34, build-tools;34.0.0
+
+
       - name: 🗃️ Cache Gradle
         uses: actions/cache@v4
         with:
@@ -104,6 +112,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Install the Android SDK for running unit tests
+      - name: 📱 Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          components: platform-tools, platforms;android-34, build-tools;34.0.0
+
+
       - name: 🗃️ Cache Gradle
         uses: actions/cache@v4
         with:
@@ -160,6 +176,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      # Install the Android SDK for lint checks
+      - name: 📱 Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          components: platform-tools, platforms;android-34, build-tools;34.0.0
 
       - name: 🗃️ Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -43,6 +43,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Install the Android SDK and build tools
+      - name: 📱 Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          components: platform-tools, platforms;android-34, build-tools;34.0.0
+
       - name: 🗃️ Setup Gradle Cache
         uses: actions/cache@v4
         with:
@@ -157,6 +164,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      # Install the Android SDK for tests
+      - name: 📱 Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          components: platform-tools, platforms;android-34, build-tools;34.0.0
 
       - name: 🗃️ Restore Gradle Cache
         uses: actions/cache@v4

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -99,6 +99,9 @@ dependencies {
     implementation(project(":android:feature-settings"))
     implementation(project(":android:feature-reader"))
     implementation(project(":android:feature-themes"))
+
+    // Include OCR feature module for language selection and translation support
+    implementation(project(":android:feature-ocr"))
     
     // Third-party libraries
     implementation(libs.coil.compose)

--- a/android/app/src/main/java/com/example/mrcomic/data/OcrTranslationRepository.kt
+++ b/android/app/src/main/java/com/example/mrcomic/data/OcrTranslationRepository.kt
@@ -1,0 +1,94 @@
+package com.example.mrcomic.data
+
+import android.content.Context
+import android.net.Uri
+import com.example.mrcomic.data.network.MrComicApiService
+import com.example.mrcomic.data.network.dto.OcrResponseDto
+import com.example.mrcomic.data.network.dto.TranslationRequestDto
+import com.example.mrcomic.data.network.dto.TranslationResponseDto
+import com.example.mrcomic.di.Resource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.catch
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+import javax.inject.Inject
+import com.google.gson.Gson
+
+/**
+ * Repository for handling OCR and translation operations.
+ *
+ * This class wraps the [MrComicApiService] calls into flows of [Resource] types so
+ * that the UI can observe loading, success and error states consistently. It converts
+ * a URI pointing to an image into a [MultipartBody.Part] required by the API and
+ * builds request bodies for optional JSON parameters when provided.
+ */
+class OcrTranslationRepository @Inject constructor(
+    private val apiService: MrComicApiService,
+    private val context: Context,
+    private val gson: Gson
+) {
+
+    /**
+     * Processes an image for OCR. Converts the provided [imageUri] into a multipart body
+     * and forwards optional region/language/parameter JSON strings as request bodies. Emits
+     * [Resource.Loading] first, followed by either [Resource.Success] or [Resource.Error].
+     */
+    fun processImageOcr(
+        imageUri: Uri,
+        regionsJson: String? = null,
+        languagesJson: String? = null,
+        ocrParamsJson: String? = null
+    ): Flow<Resource<OcrResponseDto>> = flow {
+        emit(Resource.Loading())
+        val file = File(imageUri.path ?: "")
+        if (!file.exists()) {
+            emit(Resource.Error("Image file not found"))
+            return@flow
+        }
+        val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
+        val imagePart = MultipartBody.Part.createFormData("image", file.name, requestFile)
+        val regionsBody: RequestBody? = regionsJson?.toRequestBody("application/json".toMediaTypeOrNull())
+        val languagesBody: RequestBody? = languagesJson?.toRequestBody("application/json".toMediaTypeOrNull())
+        val paramsBody: RequestBody? = ocrParamsJson?.toRequestBody("application/json".toMediaTypeOrNull())
+        val response = apiService.processImageOcr(imagePart, regionsBody, languagesBody, paramsBody)
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                emit(Resource.Success(body))
+            } else {
+                emit(Resource.Error("Empty response body"))
+            }
+        } else {
+            emit(Resource.Error("Error processing OCR: ${'$'}{response.code()}"))
+        }
+    }.catch { e ->
+        emit(Resource.Error(e.message ?: "Unknown error"))
+    }
+
+    /**
+     * Translates the given text(s) described by [requestDto]. Emits a loading state
+     * before performing the network call and returns either the translated response
+     * or an error wrapped in [Resource].
+     */
+    fun translateText(requestDto: TranslationRequestDto): Flow<Resource<TranslationResponseDto>> = flow {
+        emit(Resource.Loading())
+        val response = apiService.translateText(requestDto)
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                emit(Resource.Success(body))
+            } else {
+                emit(Resource.Error("Empty response body"))
+            }
+        } else {
+            emit(Resource.Error("Error translating text: ${'$'}{response.code()}"))
+        }
+    }.catch { e ->
+        emit(Resource.Error(e.message ?: "Unknown error"))
+    }
+}

--- a/android/app/src/main/java/com/example/mrcomic/di/AppModule.kt
+++ b/android/app/src/main/java/com/example/mrcomic/di/AppModule.kt
@@ -3,6 +3,9 @@ package com.example.mrcomic.di
 import com.example.mrcomic.data.network.MrComicApiService
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.example.mrcomic.data.OcrTranslationRepository
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/android/app/src/main/java/com/example/mrcomic/ui/AccountScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/AccountScreen.kt
@@ -34,6 +34,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/ComicDetailScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/ComicDetailScreen.kt
@@ -39,6 +39,19 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import coil.compose.AsyncImage
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
+// LaunchedEffect for side effects
+import androidx.compose.runtime.LaunchedEffect
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ComicDetailScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/LanguageSelectScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/LanguageSelectScreen.kt
@@ -31,6 +31,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.feature.ocr.ui.TranslateOcrViewModel
 import com.example.mrcomic.ui.theme.MrComicTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+
+// Compose Material3 components not imported above
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.IconButton
+import androidx.compose.foundation.clickable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/android/app/src/main/java/com/example/mrcomic/ui/LoginScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/LoginScreen.kt
@@ -35,6 +35,14 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.example.mrcomic.ui.theme.MrComicTheme
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/MainScreen.kt
@@ -36,6 +36,25 @@ import com.example.mrcomic.ui.theme.MrComicTheme
 import com.example.feature.library.ui.LibraryScreen
 import com.example.feature.themes.ui.ThemesScreen
 
+// Additional imports for navigation, paging and Material3 components
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.launch
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun MainScreen(modifier: Modifier = Modifier, navController: NavController = rememberNavController()) {

--- a/android/app/src/main/java/com/example/mrcomic/ui/OcrCropScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/OcrCropScreen.kt
@@ -36,8 +36,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.mrcomic.data.OcrTranslationRepository
 import coil.compose.rememberAsyncImagePainter
 import com.example.mrcomic.ui.theme.MrComicTheme
+
+// Additional Compose Material3 and layout imports
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/android/app/src/main/java/com/example/mrcomic/ui/OptimizationScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/OptimizationScreen.kt
@@ -26,6 +26,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.mrcomic.ui.theme.MrComicTheme
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OptimizationScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/PasswordResetScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/PasswordResetScreen.kt
@@ -30,6 +30,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.mrcomic.ui.theme.MrComicTheme
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordResetScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/ReaderMenuScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/ReaderMenuScreen.kt
@@ -31,6 +31,14 @@ import com.example.feature.reader.ui.ReaderViewModel
 import com.example.feature.reader.ui.ReadingMode
 import com.example.feature.reader.ui.ReadingDirection
 
+// Additional Material3 imports for Scaffold, top bar and buttons
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReaderMenuScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/ReaderSettingsScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/ReaderSettingsScreen.kt
@@ -26,6 +26,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.mrcomic.ui.theme.MrComicTheme
 
+// Additional Material3 imports for Scaffold and top bar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReaderSettingsScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/SearchScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/SearchScreen.kt
@@ -33,6 +33,15 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 
+// Additional Material3 imports for Scaffold, top bar, text field and progress
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(viewModel: SearchViewModel = viewModel()) {

--- a/android/app/src/main/java/com/example/mrcomic/ui/SearchViewModel.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/SearchViewModel.kt
@@ -1,0 +1,99 @@
+package com.example.mrcomic.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import androidx.lifecycle.viewModelScope
+
+// A simple data model representing an item returned by a search operation.
+data class SearchResult(
+    val id: String,
+    val title: String,
+    val author: String,
+    val coverUrl: String
+)
+
+// Represent the various states of the search screen.
+sealed class SearchState {
+    object Idle : SearchState()      // Initial or idle state
+    object Loading : SearchState()   // Indicates the search is in progress
+    data class Success(val results: List<SearchResult>) : SearchState() // Search returned results
+    object Empty : SearchState()     // Search completed but nothing matched
+    data class Error(val message: String) : SearchState() // Search encountered an error
+}
+
+/**
+ * ViewModel responsible for managing the state of the search screen. It exposes the current
+ * search query and a state flow representing the loading state and results. A simple in-memory
+ * list acts as the data source. When the query changes, the ViewModel debounces the input
+ * before filtering the list to simulate an asynchronous search operation.
+ */
+class SearchViewModel : ViewModel() {
+
+    // Holds the text entered by the user for the search query.
+    var searchQuery by mutableStateOf("")
+        private set
+
+    // Internal mutable state flow representing the current search state.
+    private val _searchState = MutableStateFlow<SearchState>(SearchState.Idle)
+
+    // Exposes an immutable state flow to observers of this ViewModel.
+    val searchState: StateFlow<SearchState> = _searchState.asStateFlow()
+
+    // A reference to the current coroutine job used for debouncing search queries.
+    private var searchJob: Job? = null
+
+    // A static list of comics used as a simple search data source.
+    private val allComics = listOf(
+        SearchResult("1", "One-Punch Man", "ONE", "https://placehold.co/200x300?text=OPM"),
+        SearchResult("2", "Berserk", "Kentaro Miura", "https://placehold.co/200x300?text=Berserk"),
+        SearchResult("3", "Vinland Saga", "Makoto Yukimura", "https://placehold.co/200x300?text=Vinland"),
+        SearchResult("4", "Attack on Titan", "Hajime Isayama", "https://placehold.co/200x300?text=AoT"),
+        SearchResult("5", "Solo Leveling", "Chugong", "https://placehold.co/200x300?text=Solo")
+    )
+
+    /**
+     * Called when the user modifies the search query. Cancels any ongoing search and if the
+     * query is non-blank starts a new coroutine that debounces the input by 500 ms before
+     * performing the search. Results are posted to the state flow.
+     */
+    fun onSearchQueryChanged(query: String) {
+        searchQuery = query
+        searchJob?.cancel()
+
+        // Reset to idle state if the query is empty
+        if (query.isBlank()) {
+            _searchState.value = SearchState.Idle
+            return
+        }
+
+        searchJob = viewModelScope.launch {
+            _searchState.value = SearchState.Loading
+            delay(500) // Debounce to prevent searching on every keystroke
+
+            try {
+                // Perform a simple filter on the local list of comics
+                val results = allComics.filter {
+                    it.title.contains(query, ignoreCase = true) ||
+                        it.author.contains(query, ignoreCase = true)
+                }
+
+                // Emit the appropriate state based on the results
+                _searchState.value = if (results.isNotEmpty()) {
+                    SearchState.Success(results)
+                } else {
+                    SearchState.Empty
+                }
+            } catch (e: Exception) {
+                _searchState.value = SearchState.Error("Произошла ошибка поиска")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/mrcomic/ui/ThemesScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/ThemesScreen.kt
@@ -35,6 +35,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.example.feature.themes.ui.ThemesViewModel
 
+// Additional Material3 imports for Scaffold and related components
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ThemesScreen(

--- a/android/app/src/main/java/com/example/mrcomic/ui/TranslateOcrScreen.kt
+++ b/android/app/src/main/java/com/example/mrcomic/ui/TranslateOcrScreen.kt
@@ -32,11 +32,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.mrcomic.data.OcrTranslationRepository
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.mrcomic.data.network.dto.TextToTranslateDto
 import com.example.mrcomic.data.network.dto.TranslationParametersDto
 import com.example.mrcomic.ui.theme.MrComicTheme
+
+// Additional Compose runtime and Material3 imports
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/AddComicUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/AddComicUseCase.kt
@@ -2,6 +2,7 @@ package com.example.core.domain.usecase
 
 import com.example.core.data.repository.LibraryRepository
 import com.example.core.model.Comic
+import com.example.core.domain.util.Result
 import com.mrcomic.shared.logging.Log
 import javax.inject.Inject
 

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/DeleteComicUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/DeleteComicUseCase.kt
@@ -1,6 +1,7 @@
 package com.example.core.domain.usecase
 
 import com.example.core.data.repository.LibraryRepository
+import com.example.core.domain.util.Result
 import javax.inject.Inject
 import com.mrcomic.shared.logging.Log
 

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
@@ -2,6 +2,7 @@ package com.example.core.domain.usecase
 
 import android.graphics.Bitmap
 import com.example.feature.reader.domain.BookReaderFactory
+import com.example.core.domain.util.Result
 import javax.inject.Inject
 
 class GetComicPagesUseCase @Inject constructor(

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
@@ -1,6 +1,7 @@
 package com.example.core.domain.usecase
 
 import com.example.core.data.repository.ComicRepository
+import com.example.core.domain.util.Result
 import javax.inject.Inject
 
 class GetReadingProgressUseCase @Inject constructor(

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
@@ -2,6 +2,7 @@ package com.example.core.domain.usecase
 
 import android.net.Uri
 import com.example.feature.reader.domain.BookReaderFactory
+import com.example.core.domain.util.Result
 import javax.inject.Inject
 
 class LoadComicUseCase @Inject constructor(

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
@@ -1,6 +1,7 @@
 package com.example.core.domain.usecase
 
 import com.example.core.data.repository.ComicRepository
+import com.example.core.domain.util.Result
 import javax.inject.Inject
 
 class SaveReadingProgressUseCase @Inject constructor(


### PR DESCRIPTION
This pull request cleans up outdated code by removing obsolete Java-based comic reader implementations and related tests, as well as a deprecated ComicPageProvider. It also includes earlier fixes for compilation issues, PDF reader fallback and GitHub Actions workflows.