### PR TITLE
Add permission checks and improve library screen

### DIFF
--- a/android/app/src/androidTest/java/com/example/mrcomic/ui/library/LibraryScreenTest.kt
+++ b/android/app/src/androidTest/java/com/example/mrcomic/ui/library/LibraryScreenTest.kt
@@ -1,10 +1,15 @@
 package com.example.mrcomic.ui.library
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.example.feature.library.ui.LibraryScreen
+import com.example.feature.library.ui.LibraryViewModel
+import com.example.core.data.repository.ComicRepository
+import com.example.core.model.Bookmark
+import com.example.core.model.Comic
+import com.example.core.model.SortOrder
 import com.example.mrcomic.ui.BaseUITest
 import com.example.mrcomic.ui.utils.ComposeTestUtils.assertButtonExists
 import com.example.mrcomic.ui.utils.ComposeTestUtils.assertIsDisplayedAndEnabled
@@ -12,7 +17,10 @@ import com.example.mrcomic.ui.utils.ComposeTestUtils.waitForElement
 import com.example.mrcomic.ui.utils.ComposeTestUtils.waitForText
 import com.example.mrcomic.ui.utils.TestData
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
+import android.net.Uri
 
 /**
  * UI тесты для экрана библиотеки комиксов
@@ -24,8 +32,12 @@ class LibraryScreenTest : BaseUITest() {
     fun libraryScreen_displaysCorrectly() {
         // Arrange & Act
         composeTestRule.setContent {
-            // TODO: Здесь будет реальный LibraryScreen когда он будет создан
-            // LibraryScreen()
+            LibraryScreen(
+                onBookClick = {},
+                onAddClick = {},
+                onSettingsClick = {},
+                viewModel = LibraryViewModel(FakeComicRepository())
+            )
         }
 
         // Assert
@@ -224,4 +236,18 @@ class LibraryScreenTest : BaseUITest() {
         
         composeTestRule.assertButtonExists(TestData.Texts.BUTTON_RETRY)
     }
+}
+
+private class FakeComicRepository : ComicRepository {
+    private val comics = MutableStateFlow<List<Comic>>(emptyList())
+    override fun getComics(sortOrder: SortOrder, searchQuery: String): Flow<List<Comic>> = comics
+    override suspend fun refreshComicsIfEmpty() {}
+    override suspend fun deleteComics(comicIds: Set<String>) {}
+    override suspend fun addComic(comic: Comic) {}
+    override suspend fun updateProgress(comicId: String, currentPage: Int) {}
+    override suspend fun clearCache() {}
+    override suspend fun importComicFromUri(uri: Uri) {}
+    override suspend fun addBookmark(bookmark: Bookmark) {}
+    override suspend fun removeBookmark(bookmark: Bookmark) {}
+    override suspend fun getBookmarks(comicId: String): List<Bookmark> = emptyList()
 }

--- a/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryScreen.kt
+++ b/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryScreen.kt
@@ -3,7 +3,6 @@ package com.example.feature.library.ui
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,12 +19,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Button
-import androidx.compose.material3.Divider
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.core.model.Comic
@@ -43,7 +42,10 @@ fun LibraryScreen(
     Scaffold(
         topBar = { TopAppBar(title = { Text("Library") }) },
         floatingActionButton = {
-            FloatingActionButton(onClick = onAddClick) {
+            FloatingActionButton(
+                onClick = onAddClick,
+                modifier = Modifier.testTag("add_comic_button")
+            ) {
                 Icon(Icons.Default.Add, contentDescription = "Add Comic")
             }
         }
@@ -53,6 +55,7 @@ fun LibraryScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .padding(16.dp)
+                .testTag("library_screen")
         ) {
             val errorText = uiState.error
             if (errorText != null) {
@@ -61,14 +64,24 @@ fun LibraryScreen(
                 Button(onClick = { viewModel.onPermissionsGranted() }) {
                     Text("Retry")
                 }
-            }
-
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(uiState.comics) { comic ->
-                    ComicRow(comic = comic, onClick = { onBookClick(comic.filePath) })
+            } else if (uiState.comics.isEmpty()) {
+                Text(text = "Библиотека пуста")
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(text = "Добавьте первый комикс")
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onAddClick) {
+                    Text("Добавить")
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag("library_list"),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.comics) { comic ->
+                        ComicRow(comic = comic, onClick = { onBookClick(comic.filePath) })
+                    }
                 }
             }
         }

--- a/android/feature-settings/src/main/java/com/example/feature/settings/ui/SettingsScreen.kt
+++ b/android/feature-settings/src/main/java/com/example/feature/settings/ui/SettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
-import androidx.compose.material3.Divider
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedTextField

--- a/plugins/host/AndroidPluginBridge.java
+++ b/plugins/host/AndroidPluginBridge.java
@@ -39,6 +39,11 @@ public class AndroidPluginBridge {
         return context.getSharedPreferences("plugin_settings_" + pluginId, Context.MODE_PRIVATE);
     }
 
+    private boolean hasPermission(String permission) {
+        SharedPreferences perms = context.getSharedPreferences("plugin_permissions_" + pluginId, Context.MODE_PRIVATE);
+        return perms.getBoolean(permission, false);
+    }
+
     private void runJsCallback(String callbackId, boolean success, String jsonResult) {
         // Убедимся, что jsonResult это валидная строка для JS, особенно если это строка JSON
         // Оборачиваем строку результата в кавычки, если это не null и не boolean/number literal
@@ -115,7 +120,10 @@ public class AndroidPluginBridge {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешений 'read_settings' для pluginId
+        if (!hasPermission("read_settings")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing read_settings permission."));
+            return;
+        }
         try {
             SharedPreferences prefs = getPluginPreferences();
             String valueJson = prefs.getString(key, defaultValueJson); // defaultValueJson уже строка JSON
@@ -129,11 +137,14 @@ public class AndroidPluginBridge {
     @JavascriptInterface
     public void settingsSet(String pluginIdFromJs, String key, String valueJson, String callbackId) {
         Log.d(TAG_PREFIX + pluginId, "settingsSet called for key: " + key + " with valueJson: " + valueJson + " callbackId: " + callbackId);
-         if (!this.pluginId.equals(pluginIdFromJs)) {
+        if (!this.pluginId.equals(pluginIdFromJs)) {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешений 'write_settings' для pluginId
+        if (!hasPermission("write_settings")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing write_settings permission."));
+            return;
+        }
         try {
             SharedPreferences prefs = getPluginPreferences();
             prefs.edit().putString(key, valueJson).apply();
@@ -151,7 +162,10 @@ public class AndroidPluginBridge {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешений 'write_settings' для pluginId
+        if (!hasPermission("write_settings")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing write_settings permission."));
+            return;
+        }
         try {
             SharedPreferences prefs = getPluginPreferences();
             prefs.edit().remove(key).apply();
@@ -167,14 +181,12 @@ public class AndroidPluginBridge {
     // Пути должны быть ограничены директорией плагина.
 
     private File getSafePluginFile(String relativePath) throws SecurityException {
-        // TODO: Реализовать проверку, что path не выходит за пределы директории плагина!
-        // Например, new File(pluginDir, relativePath).getCanonicalPath().startsWith(pluginDir.getCanonicalPath())
+        // Проверяем, что путь не выходит за пределы директории плагина
         File pluginDataDir = new File(context.getFilesDir(), "plugin_data/" + pluginId);
         if (!pluginDataDir.exists()) {
             pluginDataDir.mkdirs();
         }
         File targetFile = new File(pluginDataDir, relativePath);
-        // Проверка, что путь не пытается выйти из песочницы плагина
         if (!targetFile.getAbsoluteFile().toPath().normalize().startsWith(pluginDataDir.getAbsoluteFile().toPath().normalize())) {
             throw new SecurityException("Attempt to access file outside plugin directory: " + relativePath);
         }
@@ -185,7 +197,10 @@ public class AndroidPluginBridge {
     public void fsReadFile(String pluginIdFromJs, String path, String callbackId) {
         Log.d(TAG_PREFIX + pluginId, "fsReadFile called for path: " + path + " cbId: " + callbackId);
         if (!this.pluginId.equals(pluginIdFromJs)) { /* ... ошибка ... */ runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch.")); return; }
-        // TODO: Проверка 'read_file'
+        if (!hasPermission("read_file")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing read_file permission."));
+            return;
+        }
         try {
             File file = getSafePluginFile(path);
             if (file.exists() && file.isFile()) {
@@ -245,8 +260,11 @@ public class AndroidPluginBridge {
     @JavascriptInterface
     public void fsWriteFile(String pluginIdFromJs, String path, String dataString, String encoding, String callbackId) {
         Log.d(TAG_PREFIX + pluginId, "fsWriteFile called for path: " + path + " cbId: " + callbackId);
-         if (!this.pluginId.equals(pluginIdFromJs)) { /* ... ошибка ... */ runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch.")); return; }
-        // TODO: Проверка 'write_file'
+        if (!this.pluginId.equals(pluginIdFromJs)) { /* ... ошибка ... */ runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch.")); return; }
+        if (!hasPermission("write_file")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing write_file permission."));
+            return;
+        }
         try {
             File file = getSafePluginFile(path);
             File parentDir = file.getParentFile();
@@ -275,7 +293,10 @@ public class AndroidPluginBridge {
     public void fsExists(String pluginIdFromJs, String path, String callbackId) {
         Log.d(TAG_PREFIX + pluginId, "fsExists called for path: " + path + " cbId: " + callbackId);
         if (!this.pluginId.equals(pluginIdFromJs)) { /* ... ошибка ... */ runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch.")); return; }
-        // TODO: Проверка 'read_file' (или специальное разрешение на проверку существования)
+        if (!hasPermission("read_file")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing read_file permission."));
+            return;
+        }
         try {
             File file = getSafePluginFile(path); // getSafePluginFile может выбросить SecurityException
             boolean exists = file.exists();
@@ -298,7 +319,10 @@ public class AndroidPluginBridge {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешения 'read_image' для pluginId
+        if (!hasPermission("read_image")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing read_image permission."));
+            return;
+        }
         // TODO: Реализовать реальную логику получения данных изображения по imageId (например, из БД или файловой системы)
 
         // Заглушка: возвращаем моковые данные
@@ -338,7 +362,10 @@ public class AndroidPluginBridge {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешения 'read_text' для pluginId
+        if (!hasPermission("read_text")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing read_text permission."));
+            return;
+        }
 
         try {
             SharedPreferences prefs = getPluginTextPreferences();
@@ -358,7 +385,10 @@ public class AndroidPluginBridge {
             runJsCallback(callbackId, false, createErrorJson("permission_denied", "Plugin ID mismatch."));
             return;
         }
-        // TODO: Проверка разрешения 'write_text' или 'modify_text' для pluginId
+        if (!hasPermission("write_text")) {
+            runJsCallback(callbackId, false, createErrorJson("permission_denied", "Missing write_text permission."));
+            return;
+        }
 
         try {
             SharedPreferences prefs = getPluginTextPreferences();


### PR DESCRIPTION
## Summary
- add permission guard utilities and enforce checks in AndroidPluginBridge
- show empty library message with test tags and remove unused Divider imports
- add basic LibraryScreen instrumentation test with fake repository

## Testing
- `./gradlew detekt`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a05dc2cc8333a8bf43b77e490cd1