### PR TITLE
feat: refreshable tabbed library experience

### DIFF
--- a/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
+++ b/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 interface ComicRepository {
     fun getComics(sortOrder: SortOrder, searchQuery: String): Flow<List<Comic>>
     suspend fun refreshComicsIfEmpty()
+    suspend fun rescanLibrary()
     suspend fun deleteComics(comicIds: Set<String>)
     suspend fun addComic(comic: Comic)
     suspend fun updateProgress(comicId: String, currentPage: Int)
@@ -69,45 +70,68 @@ class ComicRepositoryImpl @Inject constructor(
             return
         }
         android.util.Log.d("ComicRepository", "🔍 No comics found, starting scan...")
+        rescanLibrary()
+    }
 
-        val comicUris = mutableListOf<Uri>()
-        var foldersToScan = settingsRepository.libraryFolders.first()
+    override suspend fun rescanLibrary() {
+        android.util.Log.d("ComicRepository", "🔄 Rescanning library folders")
+        val comicUris = discoverComicUris()
+        android.util.Log.d("ComicRepository", "📊 Found ${comicUris.size} comic files")
 
-        // Если пользователь не выбрал ни одной папки, сканируем стандартные
-        if (foldersToScan.isEmpty()) {
-            android.util.Log.d("ComicRepository", "📁 Scanning default directories...")
-            val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-            val documentsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
-            android.util.Log.d("ComicRepository", "📂 Scanning Downloads: ${downloadsDir.absolutePath}")
-            scanDirectory(downloadsDir, comicUris)
-            android.util.Log.d("ComicRepository", "📂 Scanning Documents: ${documentsDir.absolutePath}")
-            scanDirectory(documentsDir, comicUris)
-        } else {
-            android.util.Log.d("ComicRepository", "📁 Scanning ${foldersToScan.size} user-selected folders...")
-            foldersToScan.forEach { uriString ->
-                android.util.Log.d("ComicRepository", "📂 Scanning folder: $uriString")
-                scanDocumentTree(Uri.parse(uriString), comicUris)
-            }
+        if (comicUris.isEmpty()) {
+            android.util.Log.d("ComicRepository", "⚠️ No comics discovered during rescan")
+            return
         }
 
-        android.util.Log.d("ComicRepository", "📊 Found ${comicUris.size} comic files")
-        
         withContext(Dispatchers.IO) {
+            val filePaths = comicUris.map { it.toString() }
+            val existingEntities = comicDao.getComicsByFilePaths(filePaths).associateBy { it.filePath }
+
             val comicEntities = comicUris.map { uri ->
                 async {
                     android.util.Log.d("ComicRepository", "📖 Processing: $uri")
-                    val coverPath = coverExtractor.extractAndSaveCover(uri)
+                    val filePath = uri.toString()
+                    val existing = existingEntities[filePath]
+                    val coverPath = existing?.coverPath?.takeIf { it.isNotBlank() && File(it).exists() }
+                        ?: coverExtractor.extractAndSaveCover(uri)
+
                     ComicEntity(
-                        filePath = uri.toString(),
+                        filePath = filePath,
                         title = getFileName(uri) ?: "Unknown",
                         coverPath = coverPath,
-                        dateAdded = System.currentTimeMillis()
+                        dateAdded = existing?.dateAdded ?: System.currentTimeMillis()
                     )
                 }
             }.awaitAll()
+
             android.util.Log.d("ComicRepository", "💾 Saving ${comicEntities.size} comics to database")
             comicDao.insertAll(comicEntities)
             android.util.Log.d("ComicRepository", "✅ Comics saved successfully!")
+        }
+    }
+
+    private suspend fun discoverComicUris(): List<Uri> {
+        return withContext(Dispatchers.IO) {
+            val comicUris = mutableListOf<Uri>()
+            val foldersToScan = settingsRepository.libraryFolders.first()
+
+            if (foldersToScan.isEmpty()) {
+                android.util.Log.d("ComicRepository", "📁 Scanning default directories...")
+                val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                val documentsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+                android.util.Log.d("ComicRepository", "📂 Scanning Downloads: ${downloadsDir.absolutePath}")
+                scanDirectory(downloadsDir, comicUris)
+                android.util.Log.d("ComicRepository", "📂 Scanning Documents: ${documentsDir.absolutePath}")
+                scanDirectory(documentsDir, comicUris)
+            } else {
+                android.util.Log.d("ComicRepository", "📁 Scanning ${foldersToScan.size} user-selected folders...")
+                foldersToScan.forEach { uriString ->
+                    android.util.Log.d("ComicRepository", "📂 Scanning folder: $uriString")
+                    scanDocumentTree(Uri.parse(uriString), comicUris)
+                }
+            }
+
+            comicUris
         }
     }
 

--- a/android/core-ui/src/main/java/com/example/core/ui/components/ComicCards.kt
+++ b/android/core-ui/src/main/java/com/example/core/ui/components/ComicCards.kt
@@ -36,7 +36,8 @@ data class ComicInfo(
     val pageCount: Int? = null,
     val currentPage: Int = 0,
     val genre: String? = null,
-    val rating: Float? = null
+    val rating: Float? = null,
+    val filePath: String = ""
 )
 
 /**
@@ -328,7 +329,8 @@ private fun ComicCardsPreview() {
             isFavorite = true,
             pageCount = 120,
             currentPage = 78,
-            genre = "Adventure"
+            genre = "Adventure",
+            filePath = "/storage/comics/amazing.cbz"
         )
         
         Column(

--- a/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryUiState.kt
+++ b/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryUiState.kt
@@ -17,5 +17,14 @@ data class LibraryUiState(
     val pendingDeletionIds: Set<String> = emptySet(),
     // Comic counter implementation for Issue #24
     val totalComicsCount: Int = 0,
-    val visibleComicsCount: Int = 0
+    val visibleComicsCount: Int = 0,
+    val selectedTab: LibraryTab = LibraryTab.LIBRARY,
+    val isRefreshing: Boolean = false
 )
+
+enum class LibraryTab(val title: String) {
+    LIBRARY("Library"),
+    CLOUD("Cloud"),
+    ANNOTATIONS("Annotations"),
+    PLUGINS("Plugins")
+}

--- a/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryViewModel.kt
+++ b/android/feature-library/src/main/java/com/example/feature/library/ui/LibraryViewModel.kt
@@ -10,11 +10,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-import java.util.UUID
 
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
@@ -30,22 +30,25 @@ class LibraryViewModel @Inject constructor(
 
     private fun observeComics() {
         viewModelScope.launch {
-            _uiState.collectLatest { uiState ->
-                comicRepository.getComics(uiState.sortOrder, uiState.searchQuery).collectLatest { comics ->
-                    val visibleComics = comics.filter { comic ->
-                        comic.filePath !in uiState.pendingDeletionIds
-                    }
-                    
-                    _uiState.update { currentState ->
-                        currentState.copy(
-                            isLoading = false, 
-                            comics = comics,
-                            totalComicsCount = comics.size,
-                            visibleComicsCount = visibleComics.size
-                        )
+            _uiState
+                .map { it.sortOrder to it.searchQuery }
+                .distinctUntilChanged()
+                .collectLatest { (sortOrder, query) ->
+                    comicRepository.getComics(sortOrder, query).collectLatest { comics ->
+                        _uiState.update { currentState ->
+                            val visibleComics = comics.filter { comic ->
+                                comic.filePath !in currentState.pendingDeletionIds
+                            }
+
+                            currentState.copy(
+                                isLoading = false,
+                                comics = comics,
+                                totalComicsCount = comics.size,
+                                visibleComicsCount = visibleComics.size
+                            )
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -69,12 +72,38 @@ class LibraryViewModel @Inject constructor(
         _uiState.update { it.copy(searchQuery = query) }
     }
 
-    fun onToggleSearch() {
-        _uiState.update { it.copy(isSearchActive = !it.isSearchActive, searchQuery = "") }
+    fun onSearchActiveChange(isActive: Boolean) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                isSearchActive = isActive,
+                searchQuery = if (!isActive) currentState.searchQuery.trim() else currentState.searchQuery
+            )
+        }
     }
 
     fun onSortOrderChange(sortOrder: SortOrder) {
         _uiState.update { it.copy(sortOrder = sortOrder) }
+    }
+
+    fun onTabSelected(tab: LibraryTab) {
+        _uiState.update { it.copy(selectedTab = tab) }
+    }
+
+    fun refreshLibrary() {
+        if (_uiState.value.isRefreshing || _uiState.value.selectedTab != LibraryTab.LIBRARY) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true, error = null) }
+            try {
+                comicRepository.rescanLibrary()
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to refresh library")
+                }
+            } finally {
+                _uiState.update { it.copy(isRefreshing = false) }
+            }
+        }
     }
 
     fun onComicSelected(comicId: String) {

--- a/android/feature-library/src/main/java/com/example/feature/library/ui/ModernLibraryScreen.kt
+++ b/android/feature-library/src/main/java/com/example/feature/library/ui/ModernLibraryScreen.kt
@@ -1,9 +1,8 @@
 package com.example.feature.library.ui
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,54 +25,58 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.CloudQueue
+import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.FolderOpen
+import androidx.compose.material.icons.outlined.Notes
+import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.core.model.Comic
 import com.example.core.ui.components.ComicGridCard
 import com.example.core.ui.components.ComicInfo
 import com.example.core.ui.components.ComicListCard
-import com.example.core.ui.components.MrComicCard
 import com.example.core.ui.components.MrComicEmptyStateCard
 import com.example.core.ui.components.MrComicFAB
-import com.example.core.ui.components.MrComicSearchField
 import com.example.core.ui.theme.MrComicTheme
+import kotlin.math.max
 
-/**
- * Modern library screen with Material Design 3
- * 
- * Features:
- * - Large top app bar with collapsing behavior
- * - Search functionality
- * - Grid/List view toggle
- * - Filter chips
- * - Beautiful comic cards
- * - Empty states
- * - Smooth animations
- */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ModernLibraryScreen(
@@ -81,38 +84,60 @@ fun ModernLibraryScreen(
     onAddClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onVoiceSearchClick: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var searchQuery by remember { mutableStateOf("") }
-    var isGridView by remember { mutableStateOf(true) }
-    var selectedFilter by remember { mutableStateOf("All") }
-    
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    
-    // Convert Comic to ComicInfo and filter
-    val filteredComics = remember(uiState.comics, searchQuery, selectedFilter) {
-        uiState.comics
-            .map { comic -> comic.toComicInfo() }
-            .filter { comic ->
-                val matchesSearch = if (searchQuery.isBlank()) {
-                    true
-                } else {
-                    comic.title.contains(searchQuery, ignoreCase = true)
-                }
-                
-                val matchesFilter = when (selectedFilter) {
-                    "All" -> true
-                    "Recent" -> true // TODO: Add recent logic
-                    "Favorites" -> comic.isFavorite
-                    "Reading" -> comic.readingProgress > 0f
-                    else -> true
-                }
-                
-                matchesSearch && matchesFilter
-            }
+
+    var isGridView by rememberSaveable { mutableStateOf(true) }
+    var selectedFilter by rememberSaveable { mutableStateOf("All") }
+
+    val configuration = LocalConfiguration.current
+    val windowSizeClass = remember(configuration) {
+        WindowSizeClass.calculateFromSize(
+            DpSize(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp)
+        )
     }
-    
+    val columnCount = remember(windowSizeClass.widthSizeClass) {
+        when (windowSizeClass.widthSizeClass) {
+            WindowWidthSizeClass.Compact -> 2
+            WindowWidthSizeClass.Medium -> 3
+            WindowWidthSizeClass.Expanded -> 4
+            else -> 2
+        }
+    }
+
+    val comicsInfo = remember(uiState.comics) {
+        uiState.comics.map { it.toComicInfo() }
+    }
+
+    val filteredComics = remember(comicsInfo, uiState.searchQuery, selectedFilter) {
+        comicsInfo.filter { comic ->
+            val matchesSearch = if (uiState.searchQuery.isBlank()) {
+                true
+            } else {
+                comic.title.contains(uiState.searchQuery, ignoreCase = true) ||
+                    (comic.author?.contains(uiState.searchQuery, ignoreCase = true) == true)
+            }
+
+            val matchesFilter = when (selectedFilter) {
+                "Recent" -> true
+                "Favorites" -> comic.isFavorite
+                "Reading" -> comic.readingProgress > 0f
+                else -> true
+            }
+
+            matchesSearch && matchesFilter
+        }
+    }
+
+    val suggestions = remember(filteredComics, uiState.searchQuery) {
+        if (uiState.searchQuery.isBlank()) emptyList() else filteredComics.take(5)
+    }
+
+    val pullToRefreshState = rememberPullToRefreshState()
+
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
@@ -124,19 +149,24 @@ fun ModernLibraryScreen(
                     )
                 },
                 actions = {
-                    IconButton(
-                        onClick = { isGridView = !isGridView }
-                    ) {
+                    IconButton(onClick = { isGridView = !isGridView }) {
                         Icon(
                             imageVector = if (isGridView) Icons.Default.List else Icons.Default.GridView,
                             contentDescription = if (isGridView) "List view" else "Grid view"
                         )
                     }
-                    
-                    IconButton(onClick = { /* TODO: Sort options */ }) {
+
+                    IconButton(onClick = { /* TODO: Show sort dialog */ }) {
                         Icon(
                             imageVector = Icons.Default.Sort,
                             contentDescription = "Sort"
+                        )
+                    }
+
+                    IconButton(onClick = onSettingsClick) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settings"
                         )
                     }
                 },
@@ -157,123 +187,319 @@ fun ModernLibraryScreen(
         },
         contentWindowInsets = WindowInsets(0)
     ) { paddingValues ->
-        Column(
+        PullToRefreshBox(
+            state = pullToRefreshState,
+            isRefreshing = uiState.isRefreshing && uiState.selectedTab == LibraryTab.LIBRARY,
+            onRefresh = {
+                if (uiState.selectedTab == LibraryTab.LIBRARY) {
+                    viewModel.refreshLibrary()
+                }
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            // Search and filters section
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 8.dp)
+                modifier = Modifier.fillMaxSize()
             ) {
-                // Search bar
-                MrComicSearchField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    placeholder = "Search comics...",
-                    modifier = Modifier.fillMaxWidth()
-                )
-                
-                Spacer(modifier = Modifier.height(12.dp))
-                
-                // Filter chips
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 16.dp, bottom = 8.dp)
                 ) {
-                    val filters = listOf("All", "Recent", "Favorites", "Reading")
-                    filters.forEach { filter ->
-                        FilterChip(
-                            onClick = { selectedFilter = filter },
-                            label = { Text(filter) },
-                            selected = selectedFilter == filter
+                    DockedSearchBar(
+                        query = uiState.searchQuery,
+                        onQueryChange = { viewModel.onSearchQueryChange(it) },
+                        onSearch = { query ->
+                            viewModel.onSearchQueryChange(query)
+                            viewModel.onSearchActiveChange(false)
+                        },
+                        active = uiState.isSearchActive,
+                        onActiveChange = { viewModel.onSearchActiveChange(it) },
+                        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                        trailingIcon = {
+                            IconButton(onClick = onVoiceSearchClick) {
+                                Icon(Icons.Default.Mic, contentDescription = "Voice search")
+                            }
+                        },
+                        placeholder = { Text("Search your library") },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (suggestions.isNotEmpty()) {
+                            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                                items(suggestions) { suggestion ->
+                                    SearchSuggestionRow(
+                                        comic = suggestion,
+                                        onSuggestionClick = {
+                                            viewModel.onSearchQueryChange(suggestion.title)
+                                            viewModel.onSearchActiveChange(false)
+                                            onBookClick(suggestion.filePath)
+                                        }
+                                    )
+                                }
+                            }
+                        } else if (uiState.searchQuery.isNotBlank()) {
+                            Text(
+                                text = "No matches for \"${uiState.searchQuery}\"",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(16.dp)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    LibraryTabRow(
+                        selectedTab = uiState.selectedTab,
+                        onTabSelected = viewModel::onTabSelected
+                    )
+
+                    AnimatedVisibility(visible = uiState.isRefreshing) {
+                        LinearProgressIndicator(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 8.dp)
+                        )
+                    }
+
+                    if (uiState.selectedTab == LibraryTab.LIBRARY) {
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            val filters = listOf("All", "Recent", "Favorites", "Reading")
+                            filters.forEach { filter ->
+                                FilterChip(
+                                    onClick = { selectedFilter = filter },
+                                    label = { Text(filter) },
+                                    selected = selectedFilter == filter
+                                )
+                            }
+                        }
+                    }
+                }
+
+                when (uiState.selectedTab) {
+                    LibraryTab.LIBRARY -> {
+                        LibraryTabContent(
+                            uiState = uiState,
+                            filteredComics = filteredComics,
+                            isGridView = isGridView,
+                            columnCount = columnCount,
+                            onBookClick = onBookClick,
+                            onRetry = viewModel::refreshLibrary,
+                            onAddClick = onAddClick
+                        )
+                    }
+
+                    LibraryTab.CLOUD -> {
+                        LibraryPlaceholder(
+                            title = "Cloud library",
+                            description = "Connect Google Drive, Dropbox or WebDAV to sync your collection.",
+                            icon = Icons.Outlined.CloudQueue
+                        )
+                    }
+
+                    LibraryTab.ANNOTATIONS -> {
+                        LibraryPlaceholder(
+                            title = "Annotations",
+                            description = "Create highlights and notes for translated text blocks.",
+                            icon = Icons.Outlined.Notes
+                        )
+                    }
+
+                    LibraryTab.PLUGINS -> {
+                        LibraryPlaceholder(
+                            title = "Plugins",
+                            description = "Enhance your reader with community extensions and automation.",
+                            icon = Icons.Outlined.Extension
                         )
                     }
                 }
             }
-            
-            // Content area
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-            ) {
-                when {
-                    uiState.error != null -> {
-                        // Error state
-                        Column(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            MrComicEmptyStateCard(
-                                title = "Something went wrong",
-                                description = uiState.error ?: "Unknown error occurred",
-                                icon = Icons.Outlined.FolderOpen,
-                                action = {
-                                    com.example.core.ui.components.MrComicButton(
-                                        onClick = { viewModel.onPermissionsGranted() },
-                                        text = "Retry"
-                                    )
-                                }
-                            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryTabContent(
+    uiState: LibraryUiState,
+    filteredComics: List<ComicInfo>,
+    isGridView: Boolean,
+    columnCount: Int,
+    onBookClick: (String) -> Unit,
+    onRetry: () -> Unit,
+    onAddClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+    ) {
+        when {
+            uiState.error != null -> {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    MrComicEmptyStateCard(
+                        title = "Something went wrong",
+                        description = uiState.error ?: "Unknown error occurred",
+                        icon = Icons.Outlined.FolderOpen,
+                        action = {
+                            androidx.compose.material3.TextButton(onClick = onRetry) {
+                                Text("Retry")
+                            }
                         }
-                    }
-                    
-                    filteredComics.isEmpty() && searchQuery.isNotBlank() -> {
-                        // No search results
-                        Column(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            MrComicEmptyStateCard(
-                                title = "No comics found",
-                                description = "Try adjusting your search or filters",
-                                icon = Icons.Default.Search
-                            )
-                        }
-                    }
-                    
-                    uiState.comics.isEmpty() -> {
-                        // Empty library
-                        Column(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            MrComicEmptyStateCard(
-                                title = "Your library is empty",
-                                description = "Add some comics to get started",
-                                icon = Icons.Outlined.BookmarkBorder,
-                                action = {
-                                    com.example.core.ui.components.MrComicButton(
-                                        onClick = onAddClick,
-                                        text = "Add Comics",
-                                        icon = Icons.Default.Add
-                                    )
-                                }
-                            )
-                        }
-                    }
-                    
-                    else -> {
-                        // Comics grid/list
-                        if (isGridView) {
-                            ComicsGrid(
-                                comics = filteredComics,
-                                onComicClick = onBookClick
-                            )
-                        } else {
-                            ComicsList(
-                                comics = filteredComics,
-                                onComicClick = onBookClick
-                            )
-                        }
-                    }
+                    )
                 }
+            }
+
+            uiState.isLoading && filteredComics.isEmpty() -> {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    LinearProgressIndicator()
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = "Scanning your library...",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            filteredComics.isEmpty() -> {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    MrComicEmptyStateCard(
+                        title = "Your library is empty",
+                        description = "Add comics from storage or cloud services to get started.",
+                        icon = Icons.Outlined.BookmarkBorder,
+                        action = {
+                            androidx.compose.material3.TextButton(onClick = onAddClick) {
+                                Text("Add comics")
+                            }
+                        }
+                    )
+                }
+            }
+
+            else -> {
+                if (isGridView) {
+                    ComicsGrid(
+                        comics = filteredComics,
+                        onComicClick = onBookClick,
+                        columnCount = columnCount
+                    )
+                } else {
+                    ComicsList(
+                        comics = filteredComics,
+                        onComicClick = onBookClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryPlaceholder(
+    title: String,
+    description: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        MrComicEmptyStateCard(
+            title = title,
+            description = description,
+            icon = icon
+        )
+    }
+}
+
+@Composable
+private fun LibraryTabRow(
+    selectedTab: LibraryTab,
+    onTabSelected: (LibraryTab) -> Unit
+) {
+    val tabs = remember { LibraryTab.values() }
+    val selectedIndex = max(tabs.indexOf(selectedTab), 0)
+
+    TabRow(
+        selectedTabIndex = selectedIndex,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        tabs.forEachIndexed { index, tab ->
+            Tab(
+                selected = index == selectedIndex,
+                onClick = { onTabSelected(tab) },
+                text = { Text(tab.title) },
+                icon = {
+                    val icon = when (tab) {
+                        LibraryTab.LIBRARY -> Icons.Outlined.AutoStories
+                        LibraryTab.CLOUD -> Icons.Outlined.CloudQueue
+                        LibraryTab.ANNOTATIONS -> Icons.Outlined.Notes
+                        LibraryTab.PLUGINS -> Icons.Outlined.Extension
+                    }
+                    Icon(imageVector = icon, contentDescription = null)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchSuggestionRow(
+    comic: ComicInfo,
+    onSuggestionClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onSuggestionClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(
+                text = comic.title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            comic.author?.takeIf { it.isNotBlank() }?.let { author ->
+                Text(
+                    text = author,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }
@@ -283,20 +509,20 @@ fun ModernLibraryScreen(
 private fun ComicsGrid(
     comics: List<ComicInfo>,
     onComicClick: (String) -> Unit,
+    columnCount: Int,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 160.dp),
+        columns = GridCells.Fixed(columnCount),
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 80.dp), // Space for FAB
+        contentPadding = PaddingValues(bottom = 80.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(comics) { comic ->
             ComicGridCard(
                 comic = comic,
-                onClick = { onComicClick(comic.title) }, // TODO: Use proper path
-                onFavoriteClick = { /* TODO: Handle favorite */ }
+                onClick = { onComicClick(comic.filePath) }
             )
         }
     }
@@ -310,32 +536,29 @@ private fun ComicsList(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 80.dp), // Space for FAB
+        contentPadding = PaddingValues(bottom = 80.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         items(comics) { comic ->
             ComicListCard(
                 comic = comic,
-                onClick = { onComicClick(comic.title) }, // TODO: Use proper path
-                onFavoriteClick = { /* TODO: Handle favorite */ }
+                onClick = { onComicClick(comic.filePath) }
             )
         }
     }
 }
 
-/**
- * Extension function to convert Comic to ComicInfo
- */
 private fun Comic.toComicInfo(): ComicInfo {
     return ComicInfo(
         title = this.title,
         author = this.author,
         coverPath = this.coverPath,
-        readingProgress = 0f, // TODO: Get real progress from database
-        isFavorite = false, // TODO: Get real favorite status
-        pageCount = null, // TODO: Get real page count
-        currentPage = 0, // TODO: Get real current page
-        genre = null // TODO: Get real genre
+        readingProgress = 0f,
+        isFavorite = false,
+        pageCount = null,
+        currentPage = 0,
+        genre = null,
+        filePath = this.filePath
     )
 }
 


### PR DESCRIPTION
## Summary
- add a reusable rescanLibrary flow to the comic repository to rescan folders on demand
- extend the library state and view model to drive search activation, tab selection, and pull-to-refresh behaviour
- rebuild the modern library screen with a Material 3 SearchBar, tab row, adaptive grid/list layouts, and placeholders for upcoming areas
- include the comic file path in ComicInfo to navigate to the correct item from grid, list, and search suggestions

## Testing
- ./gradlew :android:app:assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c85a0226c083339fc1a3952d7c7337