### PR TITLE
Add reading progress storage and access

### DIFF
--- a/android/core-data/build.gradle.kts
+++ b/android/core-data/build.gradle.kts
@@ -36,4 +36,8 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation("androidx.documentfile:documentfile:1.0.1")
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.mockk)
+    testImplementation(libs.test.kotlinx.coroutines)
 }

--- a/android/core-data/src/main/java/com/example/core/data/database/AppDatabase.kt
+++ b/android/core-data/src/main/java/com/example/core/data/database/AppDatabase.kt
@@ -1,14 +1,24 @@
 package com.example.core.data.database
 
-import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [ComicEntity::class, BookmarkEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun comicDao(): ComicDao
+
+    companion object {
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE comics ADD COLUMN currentPage INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE comics ADD COLUMN totalPages INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+    }
 }

--- a/android/core-data/src/main/java/com/example/core/data/database/ComicDao.kt
+++ b/android/core-data/src/main/java/com/example/core/data/database/ComicDao.kt
@@ -1,10 +1,10 @@
 package com.example.core.data.database
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Delete
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -37,13 +37,15 @@ interface ComicDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertBookmark(bookmark: BookmarkEntity)
 
-    @Delete
-    suspend fun deleteBookmark(bookmark: BookmarkEntity)
-
     @Query("SELECT * FROM bookmarks WHERE comicId = :comicId ORDER BY page ASC")
     suspend fun getBookmarksForComic(comicId: String): List<BookmarkEntity>
 
-    // Progress tracking stub: no-op update to satisfy current UI expectations
-    @Query("UPDATE comics SET dateAdded = dateAdded WHERE filePath = :comicId")
-    suspend fun updateProgress(comicId: String)
+    @Delete
+    suspend fun deleteBookmark(bookmark: BookmarkEntity)
+
+    @Query("SELECT currentPage FROM comics WHERE filePath = :comicId LIMIT 1")
+    suspend fun getReadingProgress(comicId: String): Int?
+
+    @Query("UPDATE comics SET currentPage = :currentPage WHERE filePath = :comicId")
+    suspend fun updateProgress(comicId: String, currentPage: Int): Int
 }

--- a/android/core-data/src/main/java/com/example/core/data/database/ComicEntity.kt
+++ b/android/core-data/src/main/java/com/example/core/data/database/ComicEntity.kt
@@ -8,5 +8,7 @@ data class ComicEntity(
     @PrimaryKey val filePath: String,
     val title: String,
     val coverPath: String?, // Path to the cached cover image
-    val dateAdded: Long
+    val dateAdded: Long,
+    val currentPage: Int = 0,
+    val totalPages: Int = 0
 )

--- a/android/core-data/src/main/java/com/example/core/data/di/DatabaseModule.kt
+++ b/android/core-data/src/main/java/com/example/core/data/di/DatabaseModule.kt
@@ -22,7 +22,8 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             "mr_comic_database"
-        ).build()
+        ).addMigrations(AppDatabase.MIGRATION_3_4)
+            .build()
     }
 
     @Provides

--- a/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
+++ b/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
@@ -27,6 +27,7 @@ interface ComicRepository {
     suspend fun rescanLibrary()
     suspend fun deleteComics(comicIds: Set<String>)
     suspend fun addComic(comic: Comic)
+    suspend fun getReadingProgress(comicId: String): Int
     suspend fun updateProgress(comicId: String, currentPage: Int)
     suspend fun clearCache()
     suspend fun importComicFromUri(uri: android.net.Uri)
@@ -56,7 +57,9 @@ class ComicRepositoryImpl @Inject constructor(
                     title = entity.title,
                     author = "Unknown", // Assuming author is not in ComicEntity for now
                     filePath = entity.filePath,
-                    coverPath = entity.coverPath
+                    coverPath = entity.coverPath,
+                    currentPage = entity.currentPage,
+                    totalPages = entity.totalPages
                 )
             }
         }
@@ -99,7 +102,9 @@ class ComicRepositoryImpl @Inject constructor(
                         filePath = filePath,
                         title = getFileName(uri) ?: "Unknown",
                         coverPath = coverPath,
-                        dateAdded = existing?.dateAdded ?: System.currentTimeMillis()
+                        dateAdded = existing?.dateAdded ?: System.currentTimeMillis(),
+                        currentPage = existing?.currentPage ?: 0,
+                        totalPages = existing?.totalPages ?: 0
                     )
                 }
             }.awaitAll()
@@ -157,15 +162,27 @@ class ComicRepositoryImpl @Inject constructor(
                 filePath = comic.filePath,
                 title = comic.title,
                 coverPath = comic.coverPath,
-                dateAdded = System.currentTimeMillis()
+                dateAdded = System.currentTimeMillis(),
+                currentPage = comic.currentPage,
+                totalPages = comic.totalPages
             )
             comicDao.insertAll(listOf(comicEntity))
         }
     }
 
+    override suspend fun getReadingProgress(comicId: String): Int {
+        return withContext(Dispatchers.IO) {
+            comicDao.getReadingProgress(comicId)
+                ?: throw NoSuchElementException("Comic not found: $comicId")
+        }
+    }
+
     override suspend fun updateProgress(comicId: String, currentPage: Int) {
         withContext(Dispatchers.IO) {
-            comicDao.updateProgress(comicId)
+            val updatedRows = comicDao.updateProgress(comicId, currentPage)
+            if (updatedRows == 0) {
+                throw NoSuchElementException("Comic not found: $comicId")
+            }
         }
     }
 
@@ -200,7 +217,9 @@ class ComicRepositoryImpl @Inject constructor(
                 filePath = destinationFile.absolutePath,
                 title = fileName.substringBeforeLast('.'),
                 coverPath = null, // Cover can be extracted later
-                dateAdded = System.currentTimeMillis()
+                dateAdded = System.currentTimeMillis(),
+                currentPage = 0,
+                totalPages = 0
             )
 
             comicDao.insertAll(listOf(comicEntity))

--- a/android/core-data/src/test/java/com/example/core/data/repository/ComicRepositoryImplProgressTest.kt
+++ b/android/core-data/src/test/java/com/example/core/data/repository/ComicRepositoryImplProgressTest.kt
@@ -1,0 +1,82 @@
+package com.example.core.data.repository
+
+import android.content.Context
+import com.example.core.data.database.ComicDao
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.fail
+
+class ComicRepositoryImplProgressTest {
+
+    private lateinit var repository: ComicRepository
+    private lateinit var comicDao: ComicDao
+
+    @Before
+    fun setUp() {
+        val context = mockk<Context>(relaxed = true)
+        val coverExtractor = mockk<CoverExtractor>(relaxed = true)
+        comicDao = mockk()
+        val settingsRepository = mockk<SettingsRepository>(relaxed = true)
+
+        repository = ComicRepositoryImpl(
+            context = context,
+            coverExtractor = coverExtractor,
+            comicDao = comicDao,
+            settingsRepository = settingsRepository
+        )
+    }
+
+    @Test
+    fun `getReadingProgress returns stored progress`() = runTest {
+        val comicId = "comic-1"
+        coEvery { comicDao.getReadingProgress(comicId) } returns 7
+
+        val progress = repository.getReadingProgress(comicId)
+
+        assertEquals(7, progress)
+        coVerify(exactly = 1) { comicDao.getReadingProgress(comicId) }
+    }
+
+    @Test
+    fun `getReadingProgress throws when comic missing`() = runTest {
+        val comicId = "missing"
+        coEvery { comicDao.getReadingProgress(comicId) } returns null
+
+        try {
+            repository.getReadingProgress(comicId)
+            fail("Expected NoSuchElementException to be thrown")
+        } catch (e: NoSuchElementException) {
+            assertEquals("Comic not found: $comicId", e.message)
+        }
+        coVerify(exactly = 1) { comicDao.getReadingProgress(comicId) }
+    }
+
+    @Test
+    fun `updateProgress updates current page`() = runTest {
+        val comicId = "comic-2"
+        coEvery { comicDao.updateProgress(comicId, 10) } returns 1
+
+        repository.updateProgress(comicId, 10)
+
+        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 10) }
+    }
+
+    @Test
+    fun `updateProgress throws when no rows affected`() = runTest {
+        val comicId = "unknown"
+        coEvery { comicDao.updateProgress(comicId, 3) } returns 0
+
+        try {
+            repository.updateProgress(comicId, 3)
+            fail("Expected NoSuchElementException to be thrown")
+        } catch (e: NoSuchElementException) {
+            assertEquals("Comic not found: $comicId", e.message)
+        }
+        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 3) }
+    }
+}

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
@@ -9,8 +9,8 @@ class GetReadingProgressUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(comicId: String): Result<Int> {
         return try {
-            // Placeholder implementation until repository API is available
-            Result.Success(0)
+            val progress = repository.getReadingProgress(comicId)
+            Result.Success(progress)
         } catch (e: Exception) {
             Result.Error(e)
         }

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/GetReadingProgressUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/GetReadingProgressUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetReadingProgressUseCaseTest {
     fun `invoke should return error result when repository throws exception`() = runTest {
         // Given
         val comicId = "test-comic-id"
-        val exception = RuntimeException("Database error")
+        val exception = NoSuchElementException("Comic not found: $comicId")
         coEvery { repository.getReadingProgress(comicId) } throws exception
 
         // When

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/SaveReadingProgressUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/SaveReadingProgressUseCaseTest.kt
@@ -42,7 +42,7 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = "test-comic-id"
         val currentPage = 5
-        val exception = RuntimeException("Update failed")
+        val exception = NoSuchElementException("Comic not found: $comicId")
         coEvery { repository.updateProgress(comicId, currentPage) } throws exception
 
         // When

--- a/android/core-model/src/main/java/com/example/core/model/Comic.kt
+++ b/android/core-model/src/main/java/com/example/core/model/Comic.kt
@@ -4,7 +4,9 @@ data class Comic(
     val title: String,
     val author: String,
     val filePath: String,
-    val coverPath: String? = null
+    val coverPath: String? = null,
+    val currentPage: Int = 0,
+    val totalPages: Int = 0
 )
 
 


### PR DESCRIPTION
## Summary
- add currentPage and totalPages columns to the comics table with migration and DAO APIs
- expose reading progress operations through the repository and domain use cases
- cover success and error cases with new repository and updated use case unit tests

## Testing
- `./gradlew :android:core-data:testDebugUnitTest :android:core-domain:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ca31063ba48333a8edd5c31e7438ae