### PR TITLE
Implement reader state persistence and repository tests

### DIFF
--- a/android/feature-reader/src/main/java/com/example/feature/reader/ReaderRepository.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/ReaderRepository.kt
@@ -1,6 +1,7 @@
 package com.example.feature.reader
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 interface ReaderRepository {
     fun getCurrentComic(): String
@@ -9,9 +10,13 @@ interface ReaderRepository {
 }
 
 class InMemoryReaderRepository : ReaderRepository {
-    override fun getCurrentComic(): String = "Berserk (current)"
-    override fun getStateFlow(): Flow<Pair<String, Int>> = kotlinx.coroutines.flow.flowOf("Berserk" to 1)
+    private val state = MutableStateFlow("Berserk" to 1)
+
+    override fun getCurrentComic(): String = state.value.first
+
+    override fun getStateFlow(): Flow<Pair<String, Int>> = state
+
     override suspend fun setState(comicTitle: String, page: Int) {
-        // In-memory implementation
+        state.value = comicTitle to page
     }
-} 
+}

--- a/android/feature-reader/src/main/java/com/example/feature/reader/RoomReaderRepository.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/RoomReaderRepository.kt
@@ -3,17 +3,29 @@ package com.example.feature.reader
 import com.example.feature.reader.data.ReaderStateDao
 import com.example.feature.reader.data.ReaderStateEntity
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 
 class RoomReaderRepository @Inject constructor(
     private val dao: ReaderStateDao
 ) : ReaderRepository {
-    override fun getCurrentComic(): String = "" // Для совместимости, не используется
-    
-    override fun getStateFlow(): kotlinx.coroutines.flow.Flow<Pair<String, Int>> {
-        return kotlinx.coroutines.flow.flowOf(Pair("", 0))
+    override fun getCurrentComic(): String = runBlocking {
+        dao.getStateOnce()?.comicTitle.orEmpty()
     }
-    
+
+    override fun getStateFlow(): Flow<Pair<String, Int>> =
+        dao.getState().map { entity ->
+            entity?.let { it.comicTitle to it.page } ?: ("" to 0)
+        }
+
     override suspend fun setState(comicTitle: String, page: Int) {
-        // Placeholder implementation
+        dao.setState(
+            ReaderStateEntity(
+                id = 0,
+                comicTitle = comicTitle,
+                page = page
+            )
+        )
     }
-} 
+}

--- a/android/feature-reader/src/main/java/com/example/feature/reader/data/ReaderStateDao.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/data/ReaderStateDao.kt
@@ -11,6 +11,9 @@ interface ReaderStateDao {
     @Query("SELECT * FROM reader_state WHERE id = 0")
     fun getState(): Flow<ReaderStateEntity?>
 
+    @Query("SELECT * FROM reader_state WHERE id = 0")
+    suspend fun getStateOnce(): ReaderStateEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun setState(state: ReaderStateEntity)
-} 
+}

--- a/android/feature-reader/src/main/java/com/example/feature/reader/ui/ReaderViewModel.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/ui/ReaderViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.core.reader.domain.BookReader
 import com.example.core.reader.domain.BookReaderFactory
 import com.example.core.data.repository.SettingsRepository
+import com.example.feature.reader.ReaderRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,7 @@ import javax.inject.Inject
 class ReaderViewModel @Inject constructor(
     private val readerFactory: BookReaderFactory,
     private val settingsRepository: SettingsRepository,
+    private val readerRepository: ReaderRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -48,6 +50,8 @@ class ReaderViewModel @Inject constructor(
     )
 
     private var bookReader: BookReader? = null
+    private var currentComicId: String? = null
+    private var lastSavedState: Pair<String, Int>? = null
 
     companion object {
         private const val PRELOAD_DISTANCE = 1
@@ -55,6 +59,20 @@ class ReaderViewModel @Inject constructor(
     }
 
     init {
+        viewModelScope.launch {
+            readerRepository.getStateFlow().collect { state ->
+                lastSavedState = state
+                val (savedComicId, savedPage) = state
+                val currentId = currentComicId
+                if (savedComicId.isNotEmpty() && currentId != null && savedComicId == currentId) {
+                    val desiredPage = savedPage.coerceAtLeast(0)
+                    if (bookReader != null && desiredPage != _uiState.value.currentPageIndex) {
+                        loadPage(desiredPage)
+                    }
+                }
+            }
+        }
+
         // The file path is passed as a navigation argument.
         // SavedStateHandle automatically receives arguments from the NavController.
         android.util.Log.d(TAG, "🎬 ReaderViewModel initialized")
@@ -81,9 +99,19 @@ class ReaderViewModel @Inject constructor(
                 val reader = readerFactory.create(uri)
                 val pageCount = reader.open(uri)
                 bookReader = reader // Only assign if successful
+                currentComicId = uri.toString()
                 android.util.Log.d(TAG, "Book opened successfully. Page count: $pageCount")
                 _uiState.update { it.copy(pageCount = pageCount) }
-                loadPage(0) // Load the first page
+                if (pageCount > 0) {
+                    val targetPage = lastSavedState
+                        ?.takeIf { it.first == currentComicId }
+                        ?.second
+                        ?.coerceIn(0, pageCount - 1)
+                        ?: 0
+                    loadPage(targetPage)
+                } else {
+                    _uiState.update { it.copy(isLoading = false) }
+                }
             } catch (e: Exception) {
                 android.util.Log.e(TAG, "Failed to open book", e)
                 _uiState.update {
@@ -144,7 +172,7 @@ class ReaderViewModel @Inject constructor(
             } else {
                 android.util.Log.w(TAG, "Failed to load page $pageIndex")
             }
-            
+
             _uiState.update {
                 it.copy(
                     isLoading = false,
@@ -152,6 +180,13 @@ class ReaderViewModel @Inject constructor(
                     currentPageBitmap = bitmap,
                     error = if (bitmap == null) "Failed to load page ${pageIndex + 1}" else null
                 )
+            }
+            if (bitmap != null) {
+                val comicId = currentComicId
+                if (!comicId.isNullOrEmpty()) {
+                    lastSavedState = comicId to pageIndex
+                    readerRepository.setState(comicId, pageIndex)
+                }
             }
             // After updating UI, preload adjacent pages for a smoother experience
             preloadAdjacentPages(pageIndex)
@@ -192,5 +227,7 @@ class ReaderViewModel @Inject constructor(
         // Ensure resources are freed when the ViewModel is destroyed
         bookReader?.close()
         bookReader = null
+        currentComicId = null
+        lastSavedState = null
     }
 }

--- a/android/feature-reader/src/test/java/com/example/feature/reader/RoomReaderRepositoryTest.kt
+++ b/android/feature-reader/src/test/java/com/example/feature/reader/RoomReaderRepositoryTest.kt
@@ -1,0 +1,64 @@
+package com.example.feature.reader
+
+import com.example.feature.reader.data.ReaderStateDao
+import com.example.feature.reader.data.ReaderStateEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class FakeReaderStateDao : ReaderStateDao {
+    private val state = MutableStateFlow<ReaderStateEntity?>(null)
+    val persistedStates = mutableListOf<ReaderStateEntity>()
+
+    override fun getState(): Flow<ReaderStateEntity?> = state
+
+    override suspend fun getStateOnce(): ReaderStateEntity? = state.value
+
+    override suspend fun setState(state: ReaderStateEntity) {
+        persistedStates += state
+        this.state.value = state
+    }
+}
+
+class RoomReaderRepositoryTest {
+
+    @Test
+    fun `getStateFlow emits default value when there is no persisted state`() = runTest {
+        val dao = FakeReaderStateDao()
+        val repository = RoomReaderRepository(dao)
+
+        val result = repository.getStateFlow().first()
+
+        assertEquals("" to 0, result)
+    }
+
+    @Test
+    fun `setState persists entity with fixed id and updates flow`() = runTest {
+        val dao = FakeReaderStateDao()
+        val repository = RoomReaderRepository(dao)
+
+        repository.setState("Sample comic", 7)
+
+        val savedEntity = dao.persistedStates.single()
+        assertEquals(0, savedEntity.id)
+        assertEquals("Sample comic", savedEntity.comicTitle)
+        assertEquals(7, savedEntity.page)
+
+        val updated = repository.getStateFlow().first()
+        assertEquals("Sample comic" to 7, updated)
+    }
+
+    @Test
+    fun `getCurrentComic returns last saved comic title`() = runTest {
+        val dao = FakeReaderStateDao()
+        val repository = RoomReaderRepository(dao)
+
+        repository.setState("Berserk", 12)
+
+        val current = repository.getCurrentComic()
+        assertEquals("Berserk", current)
+    }
+}


### PR DESCRIPTION
## Summary
- map Room-backed reader state flow to comic/page pairs and persist with id 0
- expose a one-shot DAO query, update the in-memory repository, and make the reader ViewModel use the repository for state
- add unit tests that cover loading, saving, and current-comic retrieval from RoomReaderRepository

## Testing
- `ANDROID_HOME=/workspace/android-sdk ANDROID_SDK_ROOT=/workspace/android-sdk ./gradlew :android:feature-reader:testDebugUnitTest --console=plain --no-daemon` *(fails: Hilt KSP cannot create generated output directories)*

------
https://chatgpt.com/codex/tasks/task_b_68ca3bcfc1608333974bbff20eda2b21