### PR TITLE
Add persistent reading progress support

### DIFF
--- a/android/core-data/src/main/java/com/example/core/data/database/AppDatabase.kt
+++ b/android/core-data/src/main/java/com/example/core/data/database/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [ComicEntity::class, BookmarkEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -18,6 +18,17 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE comics ADD COLUMN currentPage INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("ALTER TABLE comics ADD COLUMN totalPages INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "UPDATE comics SET currentPage = CASE WHEN currentPage < 0 THEN 0 ELSE currentPage END"
+                )
+                db.execSQL(
+                    "UPDATE comics SET totalPages = CASE WHEN totalPages < 0 THEN 0 ELSE totalPages END"
+                )
             }
         }
     }

--- a/android/core-data/src/main/java/com/example/core/data/database/ComicDao.kt
+++ b/android/core-data/src/main/java/com/example/core/data/database/ComicDao.kt
@@ -7,6 +7,11 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
+data class ReadingProgressEntity(
+    val currentPage: Int,
+    val totalPages: Int
+)
+
 @Dao
 interface ComicDao {
     @Query("SELECT * FROM comics WHERE title LIKE '%' || :searchQuery || '%' ORDER BY title COLLATE NOCASE ASC")
@@ -43,9 +48,9 @@ interface ComicDao {
     @Delete
     suspend fun deleteBookmark(bookmark: BookmarkEntity)
 
-    @Query("SELECT currentPage FROM comics WHERE filePath = :comicId LIMIT 1")
-    suspend fun getReadingProgress(comicId: String): Int?
+    @Query("SELECT currentPage, totalPages FROM comics WHERE filePath = :comicId LIMIT 1")
+    suspend fun getReadingProgress(comicId: String): ReadingProgressEntity?
 
-    @Query("UPDATE comics SET currentPage = :currentPage WHERE filePath = :comicId")
-    suspend fun updateProgress(comicId: String, currentPage: Int): Int
+    @Query("UPDATE comics SET currentPage = :currentPage, totalPages = :totalPages WHERE filePath = :comicId")
+    suspend fun updateProgress(comicId: String, currentPage: Int, totalPages: Int): Int
 }

--- a/android/core-data/src/main/java/com/example/core/data/di/DatabaseModule.kt
+++ b/android/core-data/src/main/java/com/example/core/data/di/DatabaseModule.kt
@@ -22,7 +22,7 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             "mr_comic_database"
-        ).addMigrations(AppDatabase.MIGRATION_3_4)
+        ).addMigrations(AppDatabase.MIGRATION_3_4, AppDatabase.MIGRATION_4_5)
             .build()
     }
 

--- a/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
+++ b/android/core-data/src/main/java/com/example/core/data/repository/ComicRepository.kt
@@ -10,6 +10,7 @@ import com.example.core.model.Comic
 import com.example.core.model.SortOrder
 import com.example.core.data.database.ComicDao
 import com.example.core.data.database.ComicEntity
+import com.example.core.model.ReadingProgress
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -27,8 +28,8 @@ interface ComicRepository {
     suspend fun rescanLibrary()
     suspend fun deleteComics(comicIds: Set<String>)
     suspend fun addComic(comic: Comic)
-    suspend fun getReadingProgress(comicId: String): Int
-    suspend fun updateProgress(comicId: String, currentPage: Int)
+    suspend fun getReadingProgress(comicId: String): ReadingProgress
+    suspend fun updateProgress(comicId: String, currentPage: Int, totalPages: Int)
     suspend fun clearCache()
     suspend fun importComicFromUri(uri: android.net.Uri)
     suspend fun addBookmark(bookmark: Bookmark)
@@ -170,16 +171,21 @@ class ComicRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getReadingProgress(comicId: String): Int {
+    override suspend fun getReadingProgress(comicId: String): ReadingProgress {
         return withContext(Dispatchers.IO) {
-            comicDao.getReadingProgress(comicId)
+            val progress = comicDao.getReadingProgress(comicId)
                 ?: throw NoSuchElementException("Comic not found: $comicId")
+
+            ReadingProgress(
+                currentPage = progress.currentPage,
+                totalPages = progress.totalPages
+            )
         }
     }
 
-    override suspend fun updateProgress(comicId: String, currentPage: Int) {
+    override suspend fun updateProgress(comicId: String, currentPage: Int, totalPages: Int) {
         withContext(Dispatchers.IO) {
-            val updatedRows = comicDao.updateProgress(comicId, currentPage)
+            val updatedRows = comicDao.updateProgress(comicId, currentPage, totalPages)
             if (updatedRows == 0) {
                 throw NoSuchElementException("Comic not found: $comicId")
             }

--- a/android/core-data/src/test/java/com/example/core/data/repository/ComicRepositoryImplProgressTest.kt
+++ b/android/core-data/src/test/java/com/example/core/data/repository/ComicRepositoryImplProgressTest.kt
@@ -2,6 +2,8 @@ package com.example.core.data.repository
 
 import android.content.Context
 import com.example.core.data.database.ComicDao
+import com.example.core.data.database.ReadingProgressEntity
+import com.example.core.model.ReadingProgress
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -34,11 +36,11 @@ class ComicRepositoryImplProgressTest {
     @Test
     fun `getReadingProgress returns stored progress`() = runTest {
         val comicId = "comic-1"
-        coEvery { comicDao.getReadingProgress(comicId) } returns 7
+        coEvery { comicDao.getReadingProgress(comicId) } returns ReadingProgressEntity(7, 50)
 
         val progress = repository.getReadingProgress(comicId)
 
-        assertEquals(7, progress)
+        assertEquals(ReadingProgress(currentPage = 7, totalPages = 50), progress)
         coVerify(exactly = 1) { comicDao.getReadingProgress(comicId) }
     }
 
@@ -59,24 +61,24 @@ class ComicRepositoryImplProgressTest {
     @Test
     fun `updateProgress updates current page`() = runTest {
         val comicId = "comic-2"
-        coEvery { comicDao.updateProgress(comicId, 10) } returns 1
+        coEvery { comicDao.updateProgress(comicId, 10, 120) } returns 1
 
-        repository.updateProgress(comicId, 10)
+        repository.updateProgress(comicId, 10, 120)
 
-        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 10) }
+        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 10, 120) }
     }
 
     @Test
     fun `updateProgress throws when no rows affected`() = runTest {
         val comicId = "unknown"
-        coEvery { comicDao.updateProgress(comicId, 3) } returns 0
+        coEvery { comicDao.updateProgress(comicId, 3, 60) } returns 0
 
         try {
-            repository.updateProgress(comicId, 3)
+            repository.updateProgress(comicId, 3, 60)
             fail("Expected NoSuchElementException to be thrown")
         } catch (e: NoSuchElementException) {
             assertEquals("Comic not found: $comicId", e.message)
         }
-        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 3) }
+        coVerify(exactly = 1) { comicDao.updateProgress(comicId, 3, 60) }
     }
 }

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/GetReadingProgressUseCase.kt
@@ -2,12 +2,13 @@ package com.example.core.domain.usecase
 
 import com.example.core.data.repository.ComicRepository
 import com.example.core.domain.util.Result
+import com.example.core.model.ReadingProgress
 import javax.inject.Inject
 
 class GetReadingProgressUseCase @Inject constructor(
     private val repository: ComicRepository
 ) {
-    suspend operator fun invoke(comicId: String): Result<Int> {
+    suspend operator fun invoke(comicId: String): Result<ReadingProgress> {
         return try {
             val progress = repository.getReadingProgress(comicId)
             Result.Success(progress)

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/SaveReadingProgressUseCase.kt
@@ -7,9 +7,9 @@ import javax.inject.Inject
 class SaveReadingProgressUseCase @Inject constructor(
     private val repository: ComicRepository
 ) {
-    suspend operator fun invoke(comicId: String, currentPage: Int): Result<Unit> {
+    suspend operator fun invoke(comicId: String, currentPage: Int, totalPages: Int): Result<Unit> {
         return try {
-            repository.updateProgress(comicId, currentPage)
+            repository.updateProgress(comicId, currentPage, totalPages)
             Result.Success(Unit)
         } catch (e: Exception) {
             Result.Error(e)

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/GetReadingProgressUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/GetReadingProgressUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.example.core.domain.usecase
 
 import com.example.core.data.repository.ComicRepository
 import com.example.core.domain.util.Result
+import com.example.core.model.ReadingProgress
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -24,7 +25,7 @@ class GetReadingProgressUseCaseTest {
     fun `invoke should return success result with reading progress`() = runTest {
         // Given
         val comicId = "test-comic-id"
-        val expectedProgress = 5
+        val expectedProgress = ReadingProgress(currentPage = 5, totalPages = 100)
         coEvery { repository.getReadingProgress(comicId) } returns expectedProgress
 
         // When
@@ -54,7 +55,7 @@ class GetReadingProgressUseCaseTest {
     fun `invoke should handle zero progress`() = runTest {
         // Given
         val comicId = "new-comic-id"
-        val expectedProgress = 0
+        val expectedProgress = ReadingProgress(currentPage = 0, totalPages = 0)
         coEvery { repository.getReadingProgress(comicId) } returns expectedProgress
 
         // When
@@ -69,7 +70,7 @@ class GetReadingProgressUseCaseTest {
     fun `invoke should handle negative progress`() = runTest {
         // Given
         val comicId = "corrupted-comic-id"
-        val expectedProgress = -1
+        val expectedProgress = ReadingProgress(currentPage = -1, totalPages = 20)
         coEvery { repository.getReadingProgress(comicId) } returns expectedProgress
 
         // When

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/SaveReadingProgressUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/SaveReadingProgressUseCaseTest.kt
@@ -26,15 +26,16 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = "test-comic-id"
         val currentPage = 5
-        coEvery { repository.updateProgress(comicId, currentPage) } returns Unit
+        val pageCount = 100
+        coEvery { repository.updateProgress(comicId, currentPage, pageCount) } returns Unit
 
         // When
-        val result = saveReadingProgressUseCase.invoke(comicId, currentPage)
+        val result = saveReadingProgressUseCase.invoke(comicId, currentPage, pageCount)
 
         // Then
         assertTrue(result is Result.Success)
         assertEquals(Unit, (result as Result.Success).data)
-        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage) }
+        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage, pageCount) }
     }
 
     @Test
@@ -42,16 +43,17 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = "test-comic-id"
         val currentPage = 5
+        val pageCount = 80
         val exception = NoSuchElementException("Comic not found: $comicId")
-        coEvery { repository.updateProgress(comicId, currentPage) } throws exception
+        coEvery { repository.updateProgress(comicId, currentPage, pageCount) } throws exception
 
         // When
-        val result = saveReadingProgressUseCase.invoke(comicId, currentPage)
+        val result = saveReadingProgressUseCase.invoke(comicId, currentPage, pageCount)
 
         // Then
         assertTrue(result is Result.Error)
         assertEquals(exception, (result as Result.Error).exception)
-        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage) }
+        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage, pageCount) }
     }
 
     @Test
@@ -59,14 +61,15 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = "test-comic-id"
         val currentPage = 0
-        coEvery { repository.updateProgress(comicId, currentPage) } returns Unit
+        val pageCount = 0
+        coEvery { repository.updateProgress(comicId, currentPage, pageCount) } returns Unit
 
         // When
-        val result = saveReadingProgressUseCase.invoke(comicId, currentPage)
+        val result = saveReadingProgressUseCase.invoke(comicId, currentPage, pageCount)
 
         // Then
         assertTrue(result is Result.Success)
-        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage) }
+        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage, pageCount) }
     }
 
     @Test
@@ -74,14 +77,15 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = "test-comic-id"
         val currentPage = -1
-        coEvery { repository.updateProgress(comicId, currentPage) } returns Unit
+        val pageCount = 10
+        coEvery { repository.updateProgress(comicId, currentPage, pageCount) } returns Unit
 
         // When
-        val result = saveReadingProgressUseCase.invoke(comicId, currentPage)
+        val result = saveReadingProgressUseCase.invoke(comicId, currentPage, pageCount)
 
         // Then
         assertTrue(result is Result.Success)
-        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage) }
+        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage, pageCount) }
     }
 
     @Test
@@ -89,13 +93,14 @@ class SaveReadingProgressUseCaseTest {
         // Given
         val comicId = ""
         val currentPage = 5
-        coEvery { repository.updateProgress(comicId, currentPage) } returns Unit
+        val pageCount = 50
+        coEvery { repository.updateProgress(comicId, currentPage, pageCount) } returns Unit
 
         // When
-        val result = saveReadingProgressUseCase.invoke(comicId, currentPage)
+        val result = saveReadingProgressUseCase.invoke(comicId, currentPage, pageCount)
 
         // Then
         assertTrue(result is Result.Success)
-        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage) }
+        coVerify(exactly = 1) { repository.updateProgress(comicId, currentPage, pageCount) }
     }
 }

--- a/android/core-model/src/main/java/com/example/core/model/ReadingProgress.kt
+++ b/android/core-model/src/main/java/com/example/core/model/ReadingProgress.kt
@@ -1,0 +1,6 @@
+package com.example.core.model
+
+data class ReadingProgress(
+    val currentPage: Int,
+    val totalPages: Int
+)

--- a/android/feature-reader/src/main/java/com/example/feature/reader/ReaderViewModel.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/ReaderViewModel.kt
@@ -3,6 +3,7 @@ package com.example.feature.reader
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.core.domain.usecase.GetComicPagesUseCase
@@ -66,14 +67,19 @@ class ReaderViewModel @Inject constructor(
                             return@launch
                         }
                     }
-                    val lastReadPage = when (val progressResult = getReadingProgressUseCase(uriString)) {
-                        is Result.Success -> progressResult.data
+                    val progressResult = getReadingProgressUseCase(uriString)
+                    val lastReadPage = when (progressResult) {
+                        is Result.Success -> progressResult.data.currentPage
                         is Result.Error -> 0
+                    }.coerceIn(0, (totalPages - 1).coerceAtLeast(0))
+                    val resolvedPageCount = when (progressResult) {
+                        is Result.Success -> if (totalPages == 0) progressResult.data.totalPages else totalPages
+                        is Result.Error -> totalPages
                     }
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            pageCount = totalPages,
+                            pageCount = resolvedPageCount,
                             currentPageIndex = lastReadPage
                         )
                     }
@@ -115,8 +121,22 @@ class ReaderViewModel @Inject constructor(
                                 bitmaps = it.bitmaps.toMutableMap().apply { put(index, bmp) }
                             )
                         }
-                        saveReadingProgressUseCase(_uiState.value.comicUri, index)
-                        // result ignored
+                        when (
+                            val saveResult = saveReadingProgressUseCase(
+                                comicId = _uiState.value.comicUri,
+                                currentPage = index,
+                                totalPages = _uiState.value.pageCount
+                            )
+                        ) {
+                            is Result.Error -> {
+                                Log.e(
+                                    "ReaderViewModel",
+                                    "Failed to save reading progress",
+                                    saveResult.exception
+                                )
+                            }
+                            else -> Unit
+                        }
                     }
                 }
                 is Result.Error -> _uiState.update { it.copy(error = pageResult.exception.message ?: "Ошибка страницы") }

--- a/android/feature-reader/src/main/java/com/example/feature/reader/ui/ReaderViewModel.kt
+++ b/android/feature-reader/src/main/java/com/example/feature/reader/ui/ReaderViewModel.kt
@@ -5,6 +5,9 @@ import android.graphics.Bitmap
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.core.domain.usecase.GetReadingProgressUseCase
+import com.example.core.domain.usecase.SaveReadingProgressUseCase
+import com.example.core.domain.util.Result
 import com.example.core.reader.domain.BookReader
 import com.example.core.reader.domain.BookReaderFactory
 import com.example.core.data.repository.SettingsRepository
@@ -23,6 +26,8 @@ import javax.inject.Inject
 class ReaderViewModel @Inject constructor(
     private val readerFactory: BookReaderFactory,
     private val settingsRepository: SettingsRepository,
+    private val saveReadingProgressUseCase: SaveReadingProgressUseCase,
+    private val getReadingProgressUseCase: GetReadingProgressUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -48,6 +53,7 @@ class ReaderViewModel @Inject constructor(
     )
 
     private var bookReader: BookReader? = null
+    private var currentComicId: String? = null
 
     companion object {
         private const val PRELOAD_DISTANCE = 1
@@ -81,9 +87,22 @@ class ReaderViewModel @Inject constructor(
                 val reader = readerFactory.create(uri)
                 val pageCount = reader.open(uri)
                 bookReader = reader // Only assign if successful
+                currentComicId = uri.toString()
                 android.util.Log.d(TAG, "Book opened successfully. Page count: $pageCount")
-                _uiState.update { it.copy(pageCount = pageCount) }
-                loadPage(0) // Load the first page
+                val progressResult = getReadingProgressUseCase(currentComicId!!)
+                if (progressResult is Result.Error) {
+                    android.util.Log.w(TAG, "Failed to load reading progress", progressResult.exception)
+                }
+                val lastReadPage = when (progressResult) {
+                    is Result.Success -> progressResult.data.currentPage
+                    is Result.Error -> 0
+                }.coerceIn(0, (pageCount - 1).coerceAtLeast(0))
+                val resolvedPageCount = when (progressResult) {
+                    is Result.Success -> if (pageCount == 0) progressResult.data.totalPages else pageCount
+                    is Result.Error -> pageCount
+                }
+                _uiState.update { it.copy(pageCount = resolvedPageCount) }
+                loadPage(lastReadPage)
             } catch (e: Exception) {
                 android.util.Log.e(TAG, "Failed to open book", e)
                 _uiState.update {
@@ -152,6 +171,22 @@ class ReaderViewModel @Inject constructor(
                     currentPageBitmap = bitmap,
                     error = if (bitmap == null) "Failed to load page ${pageIndex + 1}" else null
                 )
+            }
+            currentComicId?.let { comicId ->
+                when (
+                    val saveResult = saveReadingProgressUseCase(
+                        comicId = comicId,
+                        currentPage = pageIndex,
+                        totalPages = _uiState.value.pageCount
+                    )
+                ) {
+                    is Result.Error -> android.util.Log.e(
+                        TAG,
+                        "Failed to save reading progress",
+                        saveResult.exception
+                    )
+                    else -> Unit
+                }
             }
             // After updating UI, preload adjacent pages for a smoother experience
             preloadAdjacentPages(pageIndex)


### PR DESCRIPTION
## Summary
- extend the comics table DAO to read and update both current and total pages and map it through the repository via a new ReadingProgress model
- migrate the Room database to version 5 with a safety migration and wire the new progress APIs into both reader view models
- update domain use cases and unit tests to cover the new progress contract

## Testing
- `./gradlew :android:core-data:testDebugUnitTest` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca3bcdf48883339d6b795c76c7d884