### PR TITLE
Integrate BookReaderFactory into LoadComicUseCase

### DIFF
--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/GetComicPagesUseCase.kt
@@ -53,11 +53,16 @@ class GetComicPagesUseCase @Inject constructor(
     }
 
     private suspend fun fetchPageCount(reader: BookReader): Int {
+        val currentCount = reader.getPageCount()
+        if (currentCount > 0) {
+            return currentCount
+        }
+
         val uri = bookReaderFactory.getCurrentUri()
         return if (uri != null) {
             reader.open(uri)
         } else {
-            reader.getPageCount()
+            currentCount
         }
     }
 }

--- a/android/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
+++ b/android/core-domain/src/main/java/com/example/core/domain/usecase/LoadComicUseCase.kt
@@ -2,21 +2,28 @@ package com.example.core.domain.usecase
 
 import android.net.Uri
 import com.example.core.domain.util.Result
+import com.example.core.reader.domain.BookReaderFactory
 import javax.inject.Inject
 
-class LoadComicUseCase @Inject constructor() {
+class LoadComicUseCase @Inject constructor(
+    private val bookReaderFactory: BookReaderFactory,
+) {
     suspend operator fun invoke(uri: Uri): Result<Unit> {
-        return try {
-            // Actual reader integration is handled in feature-reader. Domain just validates input.
-            if (uri.toString().isBlank()) return Result.Error(IllegalArgumentException("Empty URI"))
-            Result.Success(Unit)
-        } catch (e: Exception) {
-            Result.Error(e)
+        if (uri.toString().isBlank()) {
+            return Result.Error(IllegalArgumentException("Empty URI"))
         }
+
+        return runCatching {
+            val reader = bookReaderFactory.create(uri)
+            reader.open(uri)
+        }.fold(
+            onSuccess = { Result.Success(Unit) },
+            onFailure = { exception -> Result.Error(exception) },
+        )
     }
 
     fun releaseResources() {
-        // no-op for pure domain
+        bookReaderFactory.releaseResources()
     }
 }
 

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/GetComicPagesUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/GetComicPagesUseCaseTest.kt
@@ -29,7 +29,7 @@ class GetComicPagesUseCaseTest {
     @Before
     fun setUp() {
         bookReaderFactory = mockk(relaxed = true)
-        bookReader = mockk()
+        bookReader = mockk(relaxed = true)
         mockUri = mockk()
         every { bookReaderFactory.getCurrentReader() } returns bookReader
         every { bookReaderFactory.getCurrentUri() } returns mockUri
@@ -42,7 +42,7 @@ class GetComicPagesUseCaseTest {
     fun `getTotalPages should return success result with page count`() = runTest {
         // Given
         val expectedPageCount = 10
-        coEvery { bookReader.open(mockUri) } returns expectedPageCount
+        every { bookReader.getPageCount() } returns expectedPageCount
 
         // When
         val result = getComicPagesUseCase.getTotalPages()
@@ -50,14 +50,15 @@ class GetComicPagesUseCaseTest {
         // Then
         assertTrue(result is Result.Success)
         assertEquals(expectedPageCount, (result as Result.Success).data)
-        coVerify(exactly = 1) { bookReader.open(mockUri) }
+        verify(exactly = 1) { bookReader.getPageCount() }
+        coVerify(exactly = 0) { bookReader.open(any()) }
     }
 
     @Test
     fun `getTotalPages should reuse cached value on subsequent calls`() = runTest {
         // Given
         val expectedPageCount = 5
-        coEvery { bookReader.open(mockUri) } returns expectedPageCount
+        every { bookReader.getPageCount() } returns expectedPageCount
 
         // When
         val firstResult = getComicPagesUseCase.getTotalPages()
@@ -66,7 +67,7 @@ class GetComicPagesUseCaseTest {
         // Then
         assertEquals(expectedPageCount, (firstResult as Result.Success).data)
         assertEquals(expectedPageCount, (secondResult as Result.Success).data)
-        coVerify(exactly = 1) { bookReader.open(mockUri) }
+        verify(exactly = 1) { bookReader.getPageCount() }
     }
 
     @Test
@@ -86,6 +87,7 @@ class GetComicPagesUseCaseTest {
     fun `getTotalPages should return error when open throws`() = runTest {
         // Given
         val exception = RuntimeException("Failed to open book")
+        every { bookReader.getPageCount() } returns 0
         coEvery { bookReader.open(mockUri) } throws exception
 
         // When
@@ -170,7 +172,7 @@ class GetComicPagesUseCaseTest {
     @Test
     fun `clearCache should release resources and reset cached count`() = runTest {
         // Given
-        coEvery { bookReader.open(mockUri) } returnsMany listOf(3, 6)
+        every { bookReader.getPageCount() } returnsMany listOf(3, 6)
 
         // When
         val firstResult = getComicPagesUseCase.getTotalPages()
@@ -181,6 +183,6 @@ class GetComicPagesUseCaseTest {
         assertEquals(3, (firstResult as Result.Success).data)
         assertEquals(6, (secondResult as Result.Success).data)
         verify { bookReaderFactory.releaseResources() }
-        coVerify(exactly = 2) { bookReader.open(mockUri) }
+        verify(exactly = 2) { bookReader.getPageCount() }
     }
 }

--- a/android/core-domain/src/test/java/com/example/core/domain/usecase/LoadComicUseCaseTest.kt
+++ b/android/core-domain/src/test/java/com/example/core/domain/usecase/LoadComicUseCaseTest.kt
@@ -1,0 +1,84 @@
+package com.example.core.domain.usecase
+
+import android.net.Uri
+import com.example.core.domain.util.Result
+import com.example.core.reader.domain.BookReader
+import com.example.core.reader.domain.BookReaderFactory
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class LoadComicUseCaseTest {
+
+    private lateinit var bookReaderFactory: BookReaderFactory
+    private lateinit var bookReader: BookReader
+    private lateinit var uri: Uri
+    private lateinit var useCase: LoadComicUseCase
+
+    @Before
+    fun setUp() {
+        bookReaderFactory = mockk()
+        bookReader = mockk()
+        uri = mockk()
+        useCase = LoadComicUseCase(bookReaderFactory)
+    }
+
+    @Test
+    fun `invoke returns success when reader opens`() = runTest {
+        every { uri.toString() } returns "content://comic"
+        every { bookReaderFactory.create(uri) } returns bookReader
+        coEvery { bookReader.open(uri) } returns 5
+
+        val result = useCase(uri)
+
+        assertTrue(result is Result.Success)
+        coVerify(exactly = 1) { bookReader.open(uri) }
+    }
+
+    @Test
+    fun `invoke returns error for blank uri`() = runTest {
+        every { uri.toString() } returns ""
+
+        val result = useCase(uri)
+
+        assertTrue(result is Result.Error)
+        verify(exactly = 0) { bookReaderFactory.create(any()) }
+    }
+
+    @Test
+    fun `invoke returns error when factory throws`() = runTest {
+        every { uri.toString() } returns "content://comic"
+        every { bookReaderFactory.create(uri) } throws IllegalStateException("boom")
+
+        val result = useCase(uri)
+
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun `invoke returns error when reader open fails`() = runTest {
+        every { uri.toString() } returns "content://comic"
+        every { bookReaderFactory.create(uri) } returns bookReader
+        coEvery { bookReader.open(uri) } throws IllegalArgumentException("fail")
+
+        val result = useCase(uri)
+
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun `releaseResources delegates to factory`() {
+        justRun { bookReaderFactory.releaseResources() }
+
+        useCase.releaseResources()
+
+        verify(exactly = 1) { bookReaderFactory.releaseResources() }
+    }
+}


### PR DESCRIPTION
## Summary
- inject BookReaderFactory into LoadComicUseCase and delegate resource cleanup through the factory
- rely on the active reader instance in GetComicPagesUseCase and update the existing tests
- add dedicated LoadComicUseCase unit coverage for success, validation, and error paths

## Testing
- ./gradlew :android:core-domain:test *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca44f844848333a574103fe7cc4a76