### PR TITLE
Fix print line-break hyphens left mid-word in the text reader

### DIFF
--- a/android/engine-formats/src/main/kotlin/com/example/engine/formats/text/TextFormatReader.kt
+++ b/android/engine-formats/src/main/kotlin/com/example/engine/formats/text/TextFormatReader.kt
@@ -843,9 +843,16 @@ class TextFormatReader @Inject constructor(
     }
 
     private fun renderTxtParagraphBlock(paragraph: String): String? {
-        val lines = paragraph.lines()
+        val rawLines = paragraph.lines()
             .map { it.trim() }
             .filter { it.isNotBlank() }
+        if (rawLines.isEmpty()) return null
+
+        // Rejoin words split by printed line-break hyphenation (and drop invisible soft
+        // hyphens) before choosing a layout. Scanned/OCR books use narrow columns, so they
+        // fall into the line-break-preserving branch below; without this pass the trailing
+        // hyphens ("таинствен-" + "ные") would stay visible mid-word.
+        val lines = mergeHyphenatedLineBreaks(rawLines)
         if (lines.isEmpty()) return null
 
         val body = if (shouldPreserveTxtLineBreaks(lines)) {
@@ -855,6 +862,39 @@ class TextFormatReader @Inject constructor(
         }
         return "<p>$body</p>"
     }
+
+    /**
+     * Collapses words broken across printed lines by trailing hyphenation into whole words,
+     * regardless of whether the surrounding block keeps its line breaks. A line is treated as
+     * hyphenated when it ends with a hyphen character and the following line starts with a
+     * letter; dialogue/bullet dashes (see [isEmDashContext]) are left untouched. Soft hyphens
+     * (U+00AD) are always removed because they are invisible layout hints, not real characters.
+     */
+    private fun mergeHyphenatedLineBreaks(lines: List<String>): List<String> {
+        val cleaned = lines.map { it.stripSoftHyphens() }
+        if (cleaned.size <= 1) return cleaned
+        val merged = mutableListOf<String>()
+        val current = StringBuilder()
+        cleaned.forEachIndexed { index, line ->
+            current.append(line)
+            val nextFirst = cleaned.getOrNull(index + 1)?.firstOrNull()
+            val last = current.lastOrNull()
+            val isPrintedHyphenation = last != null && isHyphenChar(last) &&
+                nextFirst != null && nextFirst.isLetter() &&
+                !isEmDashContext(current)
+            if (isPrintedHyphenation) {
+                current.deleteCharAt(current.lastIndex)
+            } else {
+                merged += current.toString()
+                current.setLength(0)
+            }
+        }
+        if (current.isNotEmpty()) merged += current.toString()
+        return merged
+    }
+
+    private fun String.stripSoftHyphens(): String =
+        if (indexOf('\u00AD') >= 0) replace("\u00AD", "") else this
 
     private fun joinTxtProseLines(lines: List<String>): String {
         if (lines.isEmpty()) return ""

--- a/android/engine-formats/src/test/kotlin/com/example/engine/formats/text/TextHyphenationTest.kt
+++ b/android/engine-formats/src/test/kotlin/com/example/engine/formats/text/TextHyphenationTest.kt
@@ -1,0 +1,96 @@
+package com.example.engine.formats.text
+
+import android.content.ContextWrapper
+import com.example.core.model.ComicFormat
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class TextHyphenationTest {
+
+    /**
+     * Scanned / OCR'd books keep printed line-break hyphenation and have narrow columns,
+     * so they fall into the "preserve line breaks" layout path. The reader must still rejoin
+     * words split across printed lines instead of showing the hyphen mid-word.
+     */
+    @Test
+    fun txtReaderRejoinsPrintedHyphenationInShortLineBlocks() = runBlocking {
+        val sample = File.createTempFile("mrcomic-hyphenation", ".txt")
+        sample.writeText(
+            """
+            Это были таинствен-
+            ные существа, давно высох-
+            шие на солнце, наша нацио-
+            нальная гордость и слава.
+            """.trimIndent()
+        )
+
+        val reader = TextFormatReader(ContextWrapper(null), sample.absolutePath, ComicFormat.TXT)
+        try {
+            val html = reader.getHtmlPage(0).orEmpty()
+
+            assertTrue("Expected rejoined word 'таинственные'", html.contains("таинственные"))
+            assertTrue("Expected rejoined word 'высохшие'", html.contains("высохшие"))
+            assertTrue("Expected rejoined word 'национальная'", html.contains("национальная"))
+            assertFalse("Hyphenated fragment should not remain", html.contains("таинствен-"))
+            assertFalse("Hyphenated fragment should not remain", html.contains("высох-"))
+            assertFalse("Hyphenated fragment should not remain", html.contains("нацио-"))
+        } finally {
+            reader.close()
+            sample.delete()
+        }
+    }
+
+    /**
+     * Soft hyphens (U+00AD) are invisible layout hints in the source and must never be
+     * rendered, even when the surrounding block keeps its line breaks.
+     */
+    @Test
+    fun txtReaderStripsSoftHyphensInShortLineBlocks() = runBlocking {
+        val sample = File.createTempFile("mrcomic-soft-hyphen", ".txt")
+        sample.writeText(
+            "Корот\u00ADкая стро\u00ADка\n" +
+                "Втора\u00ADя строка\n" +
+                "Третья корот\u00ADкая",
+        )
+
+        val reader = TextFormatReader(ContextWrapper(null), sample.absolutePath, ComicFormat.TXT)
+        try {
+            val html = reader.getHtmlPage(0).orEmpty()
+            assertFalse("Soft hyphen must not be rendered", html.contains('\u00AD'))
+            assertTrue(html.contains("Короткая"))
+            assertTrue(html.contains("строка"))
+        } finally {
+            reader.close()
+            sample.delete()
+        }
+    }
+
+    /**
+     * Genuine em-dash dialogue markers and bullet dashes must not be swallowed by the
+     * de-hyphenation pass.
+     */
+    @Test
+    fun txtReaderKeepsDialogueDashesIntact() = runBlocking {
+        val sample = File.createTempFile("mrcomic-dialogue", ".txt")
+        sample.writeText(
+            """
+            — Привет, как дела?
+            — Хорошо, спасибо.
+            — Рад слышать это.
+            """.trimIndent()
+        )
+
+        val reader = TextFormatReader(ContextWrapper(null), sample.absolutePath, ComicFormat.TXT)
+        try {
+            val html = reader.getHtmlPage(0).orEmpty()
+            assertTrue("Dialogue dash should be preserved", html.contains("— Привет"))
+            assertTrue(html.contains("— Хорошо"))
+        } finally {
+            reader.close()
+            sample.delete()
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (bug 2.1 — «Некорректная обработка переносов слов»)

Scanned/OCR'd books keep printed line-break hyphenation and use narrow columns. Those short-line blocks fall into the reader's **line-break-preserving** layout path (`shouldPreserveTxtLineBreaks` returns `true` for lines ≤42 chars). That path joined lines with `<br/>` and **bypassed** the existing prose de-hyphenation in `joinTxtProseLines`, so words split across printed lines kept their hyphen mid-word:

- `таинствен-` + `ные` → shown as `таинствен-ные`
- `высох-` + `шие`, `нацио-` + `нальная`, …

Soft hyphens (`U+00AD`) were also left visible in that path.

## Fix

Add `mergeHyphenatedLineBreaks()` in `TextFormatReader`, applied in `renderTxtParagraphBlock` **before** the layout is chosen, so de-hyphenation happens for both the prose and line-break-preserving paths:

- A line ending in a hyphen char (`-`, `\u00AD`, `\u2011`, `\u2013`) followed by a line starting with a letter is rejoined into a whole word, dropping the hyphen.
- Soft hyphens are always stripped (they are invisible layout hints).
- Dialogue/bullet dashes are preserved via the existing `isEmDashContext` guard.

## Testing

- ✅ New `TextHyphenationTest` (rejoins printed hyphenation in short-line blocks, strips soft hyphens, keeps dialogue dashes) — failed before the change, passes after.
- ✅ Existing `TextChapterDetectionTest` and `TextDecodingTest` still pass (no regressions).
- ✅ `:engine-formats:testDebugUnitTest` overall: same ~19 pre-existing failures as a clean checkout, no new failures (124 tests, +3 new passing).

```
./gradlew --no-daemon :engine-formats:testDebugUnitTest \
  --tests "com.example.engine.formats.text.TextHyphenationTest" \
  --tests "com.example.engine.formats.text.TextChapterDetectionTest" \
  --tests "com.example.engine.formats.text.TextDecodingTest"
```

## Scope note

This addresses bug 2.1 from the reader bug list. The space-split case (`мистифи кации`) is intentionally **not** handled here: rejoining arbitrary space-separated fragments requires dictionary validation and would risk merging legitimately separate words. The other reported bugs (encoding/1.2, pagination, footnotes, TOC, vertical-feed/page layout, EPUB rendering) are tracked separately and need real reproduction samples / manual UI verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d25568-f139-4108-9fc1-4607e23e6104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d25568-f139-4108-9fc1-4607e23e6104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

